### PR TITLE
Optional types of rescaling for ST

### DIFF
--- a/src/main/java/timeseriesweka/filters/MatrixProfile.java
+++ b/src/main/java/timeseriesweka/filters/MatrixProfile.java
@@ -16,8 +16,8 @@ package timeseriesweka.filters;
 
 import experiments.data.DatasetLoading;
 import java.util.ArrayList;
-import static timeseriesweka.filters.shapelet_transforms.distance_functions.SubSeqDistance.ROUNDING_ERROR_CORRECTION;
 import utilities.ClassifierTools;
+import static utilities.rescalers.ZNormalisation.ROUNDING_ERROR_CORRECTION;
 import weka.core.Attribute;
 import weka.core.DenseInstance;
 import weka.core.Instance;

--- a/src/main/java/timeseriesweka/filters/shapelet_transforms/ApproximateShapeletTransform.java
+++ b/src/main/java/timeseriesweka/filters/shapelet_transforms/ApproximateShapeletTransform.java
@@ -255,7 +255,7 @@ public class ApproximateShapeletTransform extends ShapeletTransform{
                 
                 //Normalise series
                 double[] series = currentInstance.toDoubleArray();
-                series = this.subseqDistance.zNormalise(series, true);
+                series = this.subseqDistance.seriesRescaler.rescaleSeries(series, true);
                 
                 double[] paaSublists = new double[paaSize];
                 int[] paaSublistsSizes = new int[paaSize];

--- a/src/main/java/timeseriesweka/filters/shapelet_transforms/Shapelet.java
+++ b/src/main/java/timeseriesweka/filters/shapelet_transforms/Shapelet.java
@@ -31,6 +31,7 @@ import java.util.Comparator;
 import java.util.List;
 import utilities.class_counts.ClassCounts;
 import timeseriesweka.filters.shapelet_transforms.quality_measures.ShapeletQualityMeasure;
+import utilities.rescalers.SeriesRescaler;
 
 /**
  *

--- a/src/main/java/timeseriesweka/filters/shapelet_transforms/ShapeletTransform.java
+++ b/src/main/java/timeseriesweka/filters/shapelet_transforms/ShapeletTransform.java
@@ -54,7 +54,12 @@ import timeseriesweka.filters.shapelet_transforms.search_functions.ShapeletSearc
 import timeseriesweka.filters.shapelet_transforms.search_functions.ShapeletSearchOptions;
 import timeseriesweka.filters.shapelet_transforms.distance_functions.ImprovedOnlineSubSeqDistance;
 import timeseriesweka.filters.shapelet_transforms.distance_functions.SubSeqDistance;
+import timeseriesweka.filters.shapelet_transforms.distance_functions.SubSeqDistance.RescalerType;
 import timeseriesweka.filters.shapelet_transforms.search_functions.ShapeletSearchFactory;
+import utilities.rescalers.NoRescaling;
+import utilities.rescalers.SeriesRescaler;
+import utilities.rescalers.ZNormalisation;
+import utilities.rescalers.ZStandardisation;
 
 /**
 
@@ -363,6 +368,27 @@ public class ShapeletTransform extends SimpleBatchFilter implements SaveParamete
      */
     public void setQualityMeasure(ShapeletQualityChoice qualityChoice) {
         quality = new ShapeletQuality(qualityChoice);
+    }
+    
+    
+     /**
+     *
+     * @param type
+     */
+    public void setRescalerType(RescalerType type){
+         //TODO: don't like this, should change to match QualityChoice. 
+        SeriesRescaler sr;
+        switch(type){
+            case NONE:
+                sr = new NoRescaling();
+                break;
+            case STANDARDISATION:
+                sr = new ZStandardisation();
+                break;
+            default:
+                sr = new ZNormalisation();
+        }
+       this.subseqDistance.seriesRescaler = sr;
     }
     
         /**
@@ -1057,7 +1083,7 @@ public class ShapeletTransform extends SimpleBatchFilter implements SaveParamete
                 contentArray[i] = content.get(i);
             }
 
-            contentArray = sf.subseqDistance.zNormalise(contentArray, false);
+            contentArray = sf.subseqDistance.seriesRescaler.rescaleSeries(contentArray, false);
             
             ShapeletCandidate cand = new ShapeletCandidate();
             cand.setShapeletContent(contentArray);

--- a/src/main/java/timeseriesweka/filters/shapelet_transforms/ShapeletTransformFactory.java
+++ b/src/main/java/timeseriesweka/filters/shapelet_transforms/ShapeletTransformFactory.java
@@ -97,8 +97,9 @@ public class ShapeletTransformFactory {
                                             .useBinaryClassValue()
                                             .useCandidatePruning()
                                             .setKShapelets(Math.min(2000, n))
-                                            .setDistanceType(DistanceType.IMP_ONLINE)
+                                            .setDistanceType(DistanceType.NORMAL)
                                             .setSearchOptions(sOp)
+                                            .setRescalerType(SubSeqDistance.RescalerType.NORMALISATION)
                                             .build();
         
         return new ShapeletTransformFactory(options).getTransform();

--- a/src/main/java/timeseriesweka/filters/shapelet_transforms/ShapeletTransformFactoryOptions.java
+++ b/src/main/java/timeseriesweka/filters/shapelet_transforms/ShapeletTransformFactoryOptions.java
@@ -14,13 +14,15 @@
  */   
 package timeseriesweka.filters.shapelet_transforms;
 
+import timeseriesweka.filters.shapelet_transforms.distance_functions.SubSeqDistance;
 import timeseriesweka.filters.shapelet_transforms.quality_measures.ShapeletQuality.ShapeletQualityChoice;
 import static timeseriesweka.filters.shapelet_transforms.quality_measures.ShapeletQuality.ShapeletQualityChoice.INFORMATION_GAIN;
-import timeseriesweka.filters.shapelet_transforms.quality_measures.ShapeletQualityMeasure;
 import timeseriesweka.filters.shapelet_transforms.search_functions.ShapeletSearch;
 import timeseriesweka.filters.shapelet_transforms.search_functions.ShapeletSearchOptions;
 import timeseriesweka.filters.shapelet_transforms.distance_functions.SubSeqDistance.DistanceType;
 import static timeseriesweka.filters.shapelet_transforms.distance_functions.SubSeqDistance.DistanceType.NORMAL;
+import timeseriesweka.filters.shapelet_transforms.distance_functions.SubSeqDistance.RescalerType;
+import static timeseriesweka.filters.shapelet_transforms.distance_functions.SubSeqDistance.RescalerType.NORMALISATION;
 
 /**
  *
@@ -38,6 +40,7 @@ public class ShapeletTransformFactoryOptions {
     private final DistanceType distance;
     private final ShapeletQualityChoice qualityChoice;
     private final ShapeletSearchOptions searchOptions;
+    private final RescalerType rescalerType;
     
     
     private ShapeletTransformFactoryOptions(Builder options){
@@ -51,8 +54,13 @@ public class ShapeletTransformFactoryOptions {
         searchOptions = options.searchOptions;
         roundRobin = options.roundRobin;
         candidatePruning = options.candidatePruning;
+        rescalerType = options.rescalerType;
     }
 
+    public RescalerType  getRescalerType(){
+        return rescalerType;
+    }
+    
     public boolean isBalanceClasses() {
         return balanceClasses;
     }
@@ -110,6 +118,7 @@ public class ShapeletTransformFactoryOptions {
         private DistanceType dist;
         private ShapeletQualityChoice qualityChoice;
         private ShapeletSearchOptions searchOptions;
+        private RescalerType rescalerType;
         
         
         public Builder useRoundRobin(){
@@ -164,10 +173,17 @@ public class ShapeletTransformFactoryOptions {
             return this;
         }
         
+                
+        public Builder setRescalerType(RescalerType type){
+            rescalerType = type;
+            return this;
+        }
+        
         public ShapeletTransformFactoryOptions build(){
             setDefaults();
             return new ShapeletTransformFactoryOptions(this);
         }
+
         
         private void setDefaults(){            
             //if there is no search options. use default params;
@@ -183,6 +199,9 @@ public class ShapeletTransformFactoryOptions {
                 qualityChoice = INFORMATION_GAIN;
             }
             
+            if(rescalerType == null){
+                rescalerType = NORMALISATION;
+            }
             
             if(dist == null){
                 dist =  NORMAL;

--- a/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/CachedSubSeqDistance.java
+++ b/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/CachedSubSeqDistance.java
@@ -38,7 +38,7 @@ public class CachedSubSeqDistance extends SubSeqDistance{
         data = new double[dataSize][];
         for (int i = 0; i < dataSize; i++)
         {
-            data[i] = zNormalise(dataInst.get(i).toDoubleArray(), true);
+            data[i] = seriesRescaler.rescaleSeries(dataInst.get(i).toDoubleArray(), true);
         }
     }
     

--- a/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/MultivariateDependentDistance.java
+++ b/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/MultivariateDependentDistance.java
@@ -70,7 +70,7 @@ public class MultivariateDependentDistance extends MultivariateDistance implemen
                 //copy a section of one of the series from the channel.
                 subseq = new double[length];
                 System.arraycopy(timeSeries[j], i, subseq, 0, length);
-                subseq = zNormalise(subseq, false); // Z-NORM HERE
+                subseq = seriesRescaler.rescaleSeries(subseq, false); // Z-NORM HERE
                 for (int k = 0; k < length; k++)
                 {
                     //count ops

--- a/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/MultivariateDistance.java
+++ b/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/MultivariateDistance.java
@@ -57,7 +57,7 @@ public class MultivariateDistance extends SubSeqDistance implements Serializable
             double[] temp = new double[length];
             //copy the data from the whole series into a candidate.
             System.arraycopy(candidateArray2[i], start, temp, 0, length);
-            temp = zNormalise(temp, false); //normalise each series.
+            temp = seriesRescaler.rescaleSeries(temp, false); //normalise each series.
             cand.setShapeletContent(i, temp);
         } 
     }    

--- a/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/MultivariateIndependentDistance.java
+++ b/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/MultivariateIndependentDistance.java
@@ -70,7 +70,7 @@ public class MultivariateIndependentDistance extends MultivariateDistance implem
             subseq = new double[length];
             System.arraycopy(timeSeries, i, subseq, 0, length);
             
-            subseq = zNormalise(subseq, false); // Z-NORM HERE
+            subseq = seriesRescaler.rescaleSeries(subseq, false); // Z-NORM HERE
             for (int j = 0; j < length; j++)
             {
                 //count ops

--- a/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/OnlineCachedSubSeqDistance.java
+++ b/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/OnlineCachedSubSeqDistance.java
@@ -45,7 +45,7 @@ public class OnlineCachedSubSeqDistance extends SubSeqDistance{
         data = new double[dataSize][];
         for (int i = 0; i < dataSize; i++)
         {
-            data[i] = zNormalise(dataInst.get(i).toDoubleArray(), true);
+            data[i] = seriesRescaler.rescaleSeries(dataInst.get(i).toDoubleArray(), true);
         }
     }
     

--- a/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/OnlineSubSeqDistance.java
+++ b/src/main/java/timeseriesweka/filters/shapelet_transforms/distance_functions/OnlineSubSeqDistance.java
@@ -16,6 +16,7 @@ package timeseriesweka.filters.shapelet_transforms.distance_functions;
 
 import java.util.Arrays;
 import timeseriesweka.filters.shapelet_transforms.Shapelet;
+import static utilities.rescalers.ZNormalisation.ROUNDING_ERROR_CORRECTION;
 import weka.core.Instance;
 
 /**

--- a/src/main/java/utilities/rescalers/NoRescaling.java
+++ b/src/main/java/utilities/rescalers/NoRescaling.java
@@ -1,0 +1,29 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package utilities.rescalers;
+
+/**
+ *
+ * @author a.bostrom1
+ * 
+ * 
+ * This class just wraps up the series rescaler for no rescaling. 
+ * It allows the user to obfuscate to using classes what type of rescaling we're doing
+ * as they shouldn't care.
+ */
+public class NoRescaling implements SeriesRescaler{
+
+    @Override
+    public double[] rescaleSeries(double[] series) {
+        return rescaleSeries(series, false);
+    }
+
+    @Override
+    public double[] rescaleSeries(double[] series, boolean hasClassValue) {
+        return series;
+    }
+    
+}

--- a/src/main/java/utilities/rescalers/SeriesRescaler.java
+++ b/src/main/java/utilities/rescalers/SeriesRescaler.java
@@ -1,0 +1,17 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package utilities.rescalers;
+
+/**
+ *
+ * @author a.bostrom1
+ */
+public interface SeriesRescaler {
+   
+    
+    public double[] rescaleSeries(double[] series);
+    public double[] rescaleSeries(double[] series, boolean hasClassValue);
+}

--- a/src/main/java/utilities/rescalers/ZNormalisation.java
+++ b/src/main/java/utilities/rescalers/ZNormalisation.java
@@ -1,0 +1,74 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package utilities.rescalers;
+
+/**
+ *
+ * @author a.bostrom1
+ */
+public class ZNormalisation implements SeriesRescaler{
+
+     public static final double ROUNDING_ERROR_CORRECTION = 0.000000000000001;   
+    
+    @Override
+    public double[] rescaleSeries(double[] series) {
+        return rescaleSeries(series, false);
+    }
+
+     /**
+     * Z-Normalise a time series
+     *
+     * @param series the input time series to be z-normalised
+     * @param hasClassValue specify whether the time series includes a class value
+     * @return a z-normalised version of input
+     */
+    @Override
+    public double[] rescaleSeries(double[] series, boolean hasClassValue) {
+        double mean;
+        double stdv;
+
+        int classValPenalty = hasClassValue ? 1 : 0;
+        int inputLength = series.length - classValPenalty;
+
+        double[] output = new double[series.length];
+        double seriesTotal = 0;
+        for (int i = 0; i < inputLength; i++)
+        {
+            seriesTotal += series[i];
+        }
+
+        mean = seriesTotal / (double) inputLength;
+        stdv = 0;
+        double temp;
+        for (int i = 0; i < inputLength; i++)
+        {
+            temp = (series[i] - mean);
+            stdv += temp * temp;
+        }
+
+        stdv /= (double) inputLength;
+
+        // if the variance is less than the error correction, just set it to 0, else calc stdv.
+        stdv = (stdv < ROUNDING_ERROR_CORRECTION) ? 0.0 : Math.sqrt(stdv);
+        
+        //System.out.println("mean "+ mean);
+        //System.out.println("stdv "+stdv);
+        
+        for (int i = 0; i < inputLength; i++)
+        {
+            //if the stdv is 0 then set to 0, else normalise.
+            output[i] = (stdv == 0.0) ? 0.0 : ((series[i] - mean) / stdv);
+        }
+
+        if (hasClassValue)
+        {
+            output[output.length - 1] = series[series.length - 1];
+        }
+
+        return output;
+    }
+    
+}

--- a/src/main/java/utilities/rescalers/ZStandardisation.java
+++ b/src/main/java/utilities/rescalers/ZStandardisation.java
@@ -1,0 +1,51 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package utilities.rescalers;
+
+/**
+ *
+ * @author a.bostrom1
+ */
+public class ZStandardisation implements SeriesRescaler{
+
+    @Override
+    public double[] rescaleSeries(double[] series) {
+        return rescaleSeries(series, false);
+    }
+
+    @Override
+    public double[] rescaleSeries(double[] series, boolean hasClassValue) {
+        double mean;
+        double stdv;
+
+        int classValPenalty = hasClassValue ? 1 : 0;
+        int inputLength = series.length - classValPenalty;
+
+        double[] output = new double[series.length];
+        double seriesTotal = 0;
+        for (int i = 0; i < inputLength; i++)
+        {
+            seriesTotal += series[i];
+        }
+
+        mean = seriesTotal / (double) inputLength;
+        
+        
+        for (int i = 0; i < inputLength; i++)
+        {
+            //if the stdv is 0 then set to 0, else normalise.
+            output[i] = series[i] - mean;
+        }
+
+        if (hasClassValue)
+        {
+            output[output.length - 1] = series[series.length - 1];
+        }
+
+        return output;
+    }
+    
+}


### PR DESCRIPTION
Can turn it on or off, can choose to use standardisation. Interface to support additional rescaling types in the future.

`st.setRescalerType(SubSeqDistance.RescalerType.NONE);
st.setRescalerType(SubSeqDistance.RescalerType.STANDARDISATION);
st.setRescalerType(SubSeqDistance.RescalerType.NORMALISATION);
​
//or 
​`
​
        `ShapeletSearchOptions sOp = new ShapeletSearchOptions.Builder()
                                        .setMin(3)
                                        .setMax(m)
                                        .setSearchType(ShapeletSearch.SearchType.IMP_RANDOM)
                                        .setNumShapelets(numShapeletsToEvaluate)
                                        .setSeed(seed)
                                        .build();`
                
        `ShapeletTransformFactoryOptions options = new ShapeletTransformFactoryOptions.Builder()
                                            .useClassBalancing()
                                            .useBinaryClassValue()
                                            .useCandidatePruning()
                                            .setKShapelets(Math.min(2000, n))
                                            .setDistanceType(DistanceType.NORMAL)
                                            .setSearchOptions(sOp)
                                            .setRescalerType(SubSeqDistance.RescalerType.NORMALISATION) //setting the rescale options in the factory builder.
                                            .build();
        
        return new ShapeletTransformFactory(options).getTransform();`