### PR TITLE
RBOSS Train Estimate Changes & cTSF

### DIFF
--- a/src/main/java/experiments/ClassifierLists.java
+++ b/src/main/java/experiments/ClassifierLists.java
@@ -314,7 +314,6 @@ public class ClassifierLists {
             case "RBOSS":
                 c = new RBOSS();
                 ((RBOSS) c).setSeed(fold);
-                ((RBOSS) c).useRecommendedSettingsRBOSS();
                 break;
             case "WEASEL":
                 c = new WEASEL();

--- a/src/main/java/timeseriesweka/classifiers/dictionary_based/BOSS.java
+++ b/src/main/java/timeseriesweka/classifiers/dictionary_based/BOSS.java
@@ -319,7 +319,8 @@ public class BOSS extends AbstractClassifierWithTrainingInfo implements TrainAcc
             trainResults.setParas(getParameters());
             double result = findEnsembleTrainAcc(data);
             trainResults.finaliseResults();
-            trainResults.writeFullResultsToFile(trainCVPath);
+            if (trainCVPath != null)
+                trainResults.writeFullResultsToFile(trainCVPath);
 
             System.out.println("CV acc ="+result);
 
@@ -574,6 +575,7 @@ public class BOSS extends AbstractClassifierWithTrainingInfo implements TrainAcc
         double accuracy;
 
         c = new BOSS();
+        c.trainCV = true;
         c.buildClassifier(train);
         accuracy = ClassifierTools.accuracy(test, c);
 

--- a/src/main/java/timeseriesweka/classifiers/dictionary_based/BOSS.java
+++ b/src/main/java/timeseriesweka/classifiers/dictionary_based/BOSS.java
@@ -575,21 +575,24 @@ public class BOSS extends AbstractClassifierWithTrainingInfo implements TrainAcc
         double accuracy;
 
         c = new BOSS();
-        c.trainCV = true;
+        c.setFindTrainAccuracyEstimate(true);
         c.buildClassifier(train);
         accuracy = ClassifierTools.accuracy(test, c);
 
         System.out.println("BOSS accuracy on " + dataset + " fold " + fold + " = " + accuracy + " numClassifiers = " + Arrays.toString(c.numClassifiers));
 
         c = new BOSS();
+        c.setFindTrainAccuracyEstimate(true);
         c.buildClassifier(train2);
         accuracy = ClassifierTools.accuracy(test2, c);
 
         System.out.println("BOSS accuracy on " + dataset2 + " fold " + fold + " = " + accuracy + " numClassifiers = " + Arrays.toString(c.numClassifiers));
 
-        //Output 22/07/19
+        //Output 01/08/19
         /*
+        CV acc =0.9402985074626866
         BOSS accuracy on ItalyPowerDemand fold 0 = 0.9271137026239067 numClassifiers = [4]
+        CV acc =0.8333333333333334
         BOSS accuracy on ERing fold 0 = 0.7925925925925926 numClassifiers = [4, 1, 3, 6]
         */
     }

--- a/src/main/java/timeseriesweka/classifiers/dictionary_based/RBOSS.java
+++ b/src/main/java/timeseriesweka/classifiers/dictionary_based/RBOSS.java
@@ -779,7 +779,8 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
             if (trainTimeContract) paramTime[currentSeries].add((double)(System.nanoTime() - indivBuildTime));
             if (memoryContract) paramMemory[currentSeries].add((double)SizeOf.deepSizeOf(boss));
 
-            if (trainCV && latestTrainIdx != null){
+            if (trainCV){
+                if (boss.accuracy == -1) boss.accuracy = individualTrainAcc(boss, data, Double.MIN_VALUE);
                 for (int i = 0; i < latestTrainIdx.size(); i++){
                     idxSubsampleCount[latestTrainIdx.get(i)] += boss.weight;
                     trainDistributions[latestTrainIdx.get(i)][latestTrainPreds.get(i)] += boss.weight;

--- a/src/main/java/timeseriesweka/classifiers/dictionary_based/RBOSS.java
+++ b/src/main/java/timeseriesweka/classifiers/dictionary_based/RBOSS.java
@@ -101,7 +101,6 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
     private Instances[] prevParameters;
 
     private String checkpointPath;
-    private String serPath;
     private boolean checkpoint = false;
     private long checkpointTime = 0;
     private long checkpointTimeDiff = 0;
@@ -124,6 +123,13 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
 
     private String trainCVPath;
     private boolean trainCV = false;
+    private boolean fullTrainCVEstimate = false;
+    private double[][] trainDistributions;
+    private int[] idxSubsampleCount;
+    private ArrayList<Integer> latestTrainPreds;
+    private ArrayList<Integer> latestTrainIdx;
+    private ArrayList<ArrayList>[] filterTrainPreds;
+    private ArrayList<ArrayList>[] filterTrainIdx;
 
     private transient Instances train;
     private double ensembleCvAcc = -1;
@@ -135,7 +141,9 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
 
     protected static final long serialVersionUID = 22554L;
 
-    public RBOSS() {}
+    public RBOSS() {
+        useRecommendedSettingsRBOSS();
+    }
 
     @Override
     public TechnicalInformation getTechnicalInformation() {
@@ -188,7 +196,7 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
         return sb.toString();
     }
 
-    public void useRecommendedSettingsRBOSS(){
+    private void useRecommendedSettingsRBOSS(){
         ensembleSize = 250;
         maxEnsembleSize = 50;
         randomCVAccEnsemble = true;
@@ -320,6 +328,13 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
         lowestAcc = saved.lowestAcc;
         trainCVPath = saved.trainCVPath;
         trainCV = saved.trainCV;
+        fullTrainCVEstimate = saved.fullTrainCVEstimate;
+        trainDistributions = saved.trainDistributions;
+        idxSubsampleCount = saved.idxSubsampleCount;
+        latestTrainPreds = saved.latestTrainPreds;
+        latestTrainIdx = saved.latestTrainIdx;
+        filterTrainPreds = saved.filterTrainPreds;
+        filterTrainIdx = saved.filterTrainIdx;
         trainResults = saved.trainResults;
         ensembleCvAcc = saved.ensembleCvAcc;
         ensembleCvPreds = saved.ensembleCvPreds;
@@ -333,7 +348,7 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
             for (int i = 0; i < saved.numClassifiers[n]; i++) {
                 System.out.println("Loading BOSSIndividual" + n + "-" + i + ".ser");
 
-                FileInputStream fis = new FileInputStream(serPath + "BOSSIndividual" + n + "-" + i + ".ser");
+                FileInputStream fis = new FileInputStream(checkpointPath + "BOSSIndividual" + n + "-" + i + ".ser");
                 try (ObjectInputStream in = new ObjectInputStream(fis)) {
                     Object indv = in.readObject();
 
@@ -416,6 +431,10 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
         cleanupCheckpointFiles = b;
     }
 
+    public void setFullTrainCVEstimate(boolean b){
+        fullTrainCVEstimate = b;
+    }
+
     public void setCutoff(boolean b) {
         cutoff = b;
     }
@@ -447,33 +466,33 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
         // can classifier handle the data?
         getCapabilities().testWithFail(data);
 
-        if(data.checkForAttributeType(Attribute.RELATIONAL)){
+        if (data.checkForAttributeType(Attribute.RELATIONAL)) {
             isMultivariate = true;
         }
 
-        //path checkpoint files will be saved to
-        serPath = checkpointPath + "/" + checkpointName(data.relationName()) + "/";
-        File f = new File(serPath + "BOSS.ser");
-
         //Window length settings
-        int seriesLength = isMultivariate ? channelLength(data)-1 : data.numAttributes()-1; //minus class attribute
+        int seriesLength = isMultivariate ? channelLength(data) - 1 : data.numAttributes() - 1; //minus class attribute
         int minWindow = 10;
-        int maxWindow = (int)(seriesLength*maxWinLenProportion);
-        if (maxWindow < minWindow) minWindow = maxWindow/2;
+        int maxWindow = (int) (seriesLength * maxWinLenProportion);
+        if (maxWindow < minWindow) minWindow = maxWindow / 2;
         //whats the max number of window sizes that should be searched through
-        double maxWindowSearches = seriesLength*maxWinSearchProportion;
-        int winInc = (int)((maxWindow - minWindow) / maxWindowSearches);
+        double maxWindowSearches = seriesLength * maxWinSearchProportion;
+        int winInc = (int) ((maxWindow - minWindow) / maxWindowSearches);
         if (winInc < 1) winInc = 1;
 
+        //path checkpoint files will be saved to
+        checkpointPath = checkpointPath + "/" + checkpointName(data.relationName()) + "/";
+        File f = new File(checkpointPath + "BOSS.ser");
+
         //if checkpointing and serialised files exist load said files
-        if (checkpoint && f.exists()){
+        if (checkpoint && f.exists()) {
             long time = System.nanoTime();
-            loadFromFile(serPath + "BOSS.ser");
+            loadFromFile(checkpointPath + "BOSS.ser");
             System.out.println("Spent " + (System.nanoTime() - time) + "nanoseconds loading files");
         }
         //initialise variables
         else {
-            if (data.classIndex() != data.numAttributes()-1)
+            if (data.classIndex() != data.numAttributes() - 1)
                 throw new Exception("BOSS_BuildClassifier: Class attribute not set as last attribute in dataset");
 
             //Multivariate
@@ -481,26 +500,26 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
                 numSeries = numChannels(data);
                 classifiers = new LinkedList[numSeries];
 
-                for (int n = 0; n < numSeries; n++){
+                for (int n = 0; n < numSeries; n++) {
                     classifiers[n] = new LinkedList<>();
                 }
 
                 numClassifiers = new int[numSeries];
 
-                if (ensembleSizePerChannel > 0){
-                    ensembleSize = ensembleSizePerChannel*numSeries;
+                if (ensembleSizePerChannel > 0) {
+                    ensembleSize = ensembleSizePerChannel * numSeries;
                 }
             }
             //Univariate
-            else{
+            else {
                 numSeries = 1;
                 classifiers = new LinkedList[1];
                 classifiers[0] = new LinkedList<>();
                 numClassifiers = new int[1];
             }
 
-            if (maxEvalPerClass > 0){
-                maxEval = data.numClasses()*maxEvalPerClass;
+            if (maxEvalPerClass > 0) {
+                maxEval = data.numClasses() * maxEvalPerClass;
             }
 
             rand = new Random(seed);
@@ -508,17 +527,21 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
             parameterPool = uniqueParameters(minWindow, maxWindow, winInc);
         }
 
-        try{
+        try {
             SizeOf.deepSizeOf("test");
-        }
-        catch (IllegalStateException e){
+        } catch (IllegalStateException e) {
             if (memoryContract) {
                 throw new Exception("Unable to contract memory with SizeOf unavailable, " +
                         "enable by linking to SizeOf.jar in VM options i.e. -javaagent:lib/SizeOf.jar");
             }
         }
 
-        this.train = data;
+        train = data;
+
+        if (trainCV){
+            trainDistributions = new double[data.numInstances()][data.numClasses()];
+            idxSubsampleCount = new int[data.numInstances()];
+        }
 
         if (multiThread && numThreads == 1){
             numThreads = Runtime.getRuntime().availableProcessors();
@@ -561,16 +584,17 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
         //Estimate train accuracy
         if (trainCV) {
             trainResults.setTimeUnit(TimeUnit.NANOSECONDS);
-            trainResults.setClassifierName("RBOSS");
+            trainResults.setClassifierName("BOSS");
             trainResults.setDatasetName(data.relationName());
             trainResults.setFoldID(seed);
             trainResults.setSplit("train");
             trainResults.setParas(getParameters());
-            double result = findEnsembleTrainAcc(data);
+            ensembleCvAcc = findEnsembleTrainAcc(data);
             trainResults.finaliseResults();
-            trainResults.writeFullResultsToFile(trainCVPath);
+            if (trainCVPath != null)
+                trainResults.writeFullResultsToFile(trainCVPath);
 
-            System.out.println("CV acc ="+result);
+            System.out.println("CV acc =" + ensembleCvAcc);
 
             trainCV = false;
         }
@@ -586,6 +610,15 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
         lowestAccIdx = new int[numSeries];
         lowestAcc = new double[numSeries];
         for (int i = 0; i < numSeries; i++) lowestAcc[i] = Double.MAX_VALUE;
+
+        if (trainCV){
+            filterTrainPreds = new ArrayList[numSeries];
+            filterTrainIdx  = new ArrayList[numSeries];
+            for (int n = 0; n < numSeries; n++){
+                filterTrainPreds[n] = new ArrayList();
+                filterTrainIdx[n] = new ArrayList();
+            }
+        }
 
         //build classifiers up to a set size
         while (((underContractTime || sum(classifiersBuilt) < ensembleSize) && underMemoryLimit) && parameterPool[numSeries-1].size() > 0) {
@@ -617,6 +650,11 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
                 }
                 classifiers[currentSeries].add(boss);
                 numClassifiers[currentSeries]++;
+
+                if (trainCV){
+                    filterTrainPreds[currentSeries].add(latestTrainPreds);
+                    filterTrainIdx[currentSeries].add(latestTrainIdx);
+                }
             }
             else if (boss.accuracy > lowestAcc[currentSeries]) {
                 double[] newLowestAcc = findMinEnsembleAcc();
@@ -625,6 +663,14 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
 
                 classifiers[currentSeries].remove(lowestAccIdx[currentSeries]);
                 classifiers[currentSeries].add(lowestAccIdx[currentSeries], boss);
+
+                if (trainCV){
+                    filterTrainPreds[currentSeries].remove(lowestAccIdx[currentSeries]);
+                    filterTrainIdx[currentSeries].remove(lowestAccIdx[currentSeries]);
+                    filterTrainPreds[currentSeries].add(lowestAccIdx[currentSeries], latestTrainPreds);
+                    filterTrainIdx[currentSeries].add(lowestAccIdx[currentSeries], latestTrainIdx);
+                }
+
                 checkpointChange = true;
             }
 
@@ -660,9 +706,42 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
                     BOSSIndividual b = classifiers[n].get(i);
                     if (b.accuracy < maxAcc * correctThreshold) {
                         classifiers[currentSeries].remove(i);
+
+                        if (trainCV){
+                            filterTrainPreds[n].remove(i);
+                            filterTrainIdx[n].remove(i);
+                        }
+
                         numClassifiers[n]--;
                         i--;
                     }
+                }
+            }
+        }
+
+        if (trainCV){
+            for (int n = 0; n < numSeries; n++) {
+                for (int i = 0; i < filterTrainIdx[n].size(); i++) {
+                    ArrayList<Integer> trainIdx = filterTrainIdx[n].get(i);
+                    ArrayList<Integer> trainPreds = filterTrainPreds[n].get(i);
+                    for (int g = 0; g < trainIdx.size(); g++) {
+                        idxSubsampleCount[trainIdx.get(g)]++;
+                        trainDistributions[trainIdx.get(g)][trainPreds.get(g)]++;
+                    }
+                }
+            }
+
+            filterTrainPreds = null;
+            filterTrainIdx = null;
+            latestTrainPreds = null;
+            latestTrainIdx = null;
+
+            for (int i = 0; i < trainDistributions.length; i++){
+                if (idxSubsampleCount[i] > 0) {
+                    for (int n = 0; n < trainDistributions[i].length; n++) {
+                        trainDistributions[i][n] /= idxSubsampleCount[i];
+                    }
+                    //System.out.println(Arrays.toString(trainDistributions[i]));
                 }
             }
         }
@@ -697,6 +776,13 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
             if (trainTimeContract) paramTime[currentSeries].add((double)(System.nanoTime() - indivBuildTime));
             if (memoryContract) paramMemory[currentSeries].add((double)SizeOf.deepSizeOf(boss));
 
+            if (trainCV){
+                for (int i = 0; i < latestTrainIdx.size(); i++){
+                    idxSubsampleCount[latestTrainIdx.get(i)]++;
+                    trainDistributions[latestTrainIdx.get(i)][latestTrainPreds.get(i)]++;
+                }
+            }
+
             int prev = currentSeries;
             if (isMultivariate){
                 nextSeries();
@@ -708,12 +794,25 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
 
             checkContracts();
         }
+
+        if (trainCV){
+            latestTrainPreds = null;
+            latestTrainIdx = null;
+
+            for (int i = 0; i < trainDistributions.length; i++){
+                if (idxSubsampleCount[i] > 0) {
+                    for (int n = 0; n < trainDistributions[i].length; n++) {
+                        trainDistributions[i][n] /= idxSubsampleCount[i];
+                    }
+                }
+            }
+        }
     }
 
     private void checkpoint(int seriesNo, int classifierNo){
         if(checkpointPath!=null){
             try{
-                File f = new File(serPath);
+                File f = new File(checkpointPath);
                 if(!f.isDirectory())
                     f.mkdirs();
                 //time the checkpoint occured
@@ -725,7 +824,7 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
                     //save the last build individual classifier
                     BOSSIndividual indiv = classifiers[seriesNo].get(classifierNo);
 
-                    FileOutputStream fos = new FileOutputStream(serPath + "BOSSIndividual" + seriesNo + "-" + classifierNo + ".ser");
+                    FileOutputStream fos = new FileOutputStream(checkpointPath + "BOSSIndividual" + seriesNo + "-" + classifierNo + ".ser");
                     try (ObjectOutputStream out = new ObjectOutputStream(fos)) {
                         out.writeObject(indiv);
                         out.close();
@@ -738,10 +837,10 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
                 checkpointTime = System.nanoTime();
 
                 //save this, classifiers and train data not included
-                saveToFile(serPath + "RandomBOSStemp.ser");
+                saveToFile(checkpointPath + "RandomBOSStemp.ser");
 
-                File file = new File(serPath + "RandomBOSStemp.ser");
-                File file2 = new File(serPath + "BOSS.ser");
+                File file = new File(checkpointPath + "RandomBOSStemp.ser");
+                File file2 = new File(checkpointPath + "BOSS.ser");
                 file2.delete();
                 file.renameTo(file2);
 
@@ -749,13 +848,13 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
             }
             catch(Exception e){
                 e.printStackTrace();
-                System.out.println("Serialisation to "+serPath+" FAILED");
+                System.out.println("Serialisation to "+checkpointPath+" FAILED");
             }
         }
     }
 
     private void checkpointCleanup(){
-        File f = new File(serPath);
+        File f = new File(checkpointPath);
         String[] files = f.list();
 
         for (String file: files){
@@ -995,6 +1094,11 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
     private double individualTrainAcc(BOSSIndividual boss, Instances series, double lowestAcc) throws Exception {
         int[] indicies;
 
+        if (trainCV){
+            latestTrainPreds = new ArrayList();
+            latestTrainIdx = new ArrayList();
+        }
+
         if (useFastTrainEstimate && maxEval < series.numInstances()){
             RandomRoundRobinIndexSampler sampler = new RandomRoundRobinIndexSampler(rand);
             sampler.setInstances(series);
@@ -1034,6 +1138,11 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
                 if (t.nn == series.get(t.testIndex).classValue()) {
                     ++correct;
                 }
+
+                if (trainCV){
+                    latestTrainPreds.add((int)t.nn);
+                    latestTrainIdx.add(t.testIndex);
+                }
             }
         }
         else {
@@ -1045,6 +1154,11 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
                 double c = boss.classifyInstance(indicies[i]); //classify series i, while ignoring its corresponding histogram i
                 if (c == series.get(indicies[i]).classValue()) {
                     ++correct;
+                }
+
+                if (trainCV){
+                    latestTrainPreds.add((int)c);
+                    latestTrainIdx.add(indicies[i]);
                 }
             }
         }
@@ -1063,34 +1177,39 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
 
     private double findEnsembleTrainAcc(Instances data) throws Exception {
         this.ensembleCvPreds = new double[data.numInstances()];
-
+        int totalClassifers = sum(numClassifiers);
         double correct = 0;
+
+        if (idxSubsampleCount == null) idxSubsampleCount = new int[train.numInstances()];
+
         for (int i = 0; i < data.numInstances(); ++i) {
-            long predTime = System.nanoTime();
-            double[] probs = distributionForInstance(i, data.numClasses());
-            predTime = System.nanoTime() - predTime;
+            double[] probs;
+
+            if (idxSubsampleCount[i] > 0 && (!fullTrainCVEstimate || idxSubsampleCount[i] == totalClassifers)){
+                probs = trainDistributions[i];
+            }
+            else {
+                probs = distributionForInstance(i, data.numClasses());
+            }
 
             double c = 0;
             for (int j = 1; j < probs.length; j++)
                 if (probs[j] > probs[(int) c])
                     c = j;
 
-            //No need to do it againclassifyInstance(i, data.numClasses()); //classify series i, while ignoring its corresponding histogram i
             if (c == data.get(i).classValue())
                 ++correct;
 
             this.ensembleCvPreds[i] = c;
 
-            trainResults.addPrediction(data.get(i).classValue(), probs, c, predTime, "");
+            trainResults.addPrediction(data.get(i).classValue(), probs, c, -1, "");
         }
 
-        double result = correct / data.numInstances();
-
-        return result;
+        return correct / data.numInstances();
     }
 
     public double getTrainAcc(){
-        if(ensembleCvAcc>=0){
+        if(ensembleCvAcc >= 0){
             return this.ensembleCvAcc;
         }
 
@@ -1099,11 +1218,12 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
         }catch(Exception e){
             e.printStackTrace();
         }
+
         return -1;
     }
 
     public double[] getTrainPreds(){
-        if(this.ensembleCvPreds==null){
+        if(this.ensembleCvPreds == null){
             try{
                 this.findEnsembleTrainAcc(train);
             }catch(Exception e){
@@ -1116,8 +1236,8 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
 
     //potentially scuffed when train set is subsampled, will have to revisit and discuss if this is a viable option
     //for estimation anyway.
-    private double[] distributionForInstance(int test, int numclasses) throws Exception {
-        double[][] classHist = new double[numSeries][numclasses];
+    private double[] distributionForInstance(int test, int numClasses) throws Exception {
+        double[][] classHist = new double[numSeries][numClasses];
 
         //get sum of all channels, votes from each are weighted the same.
         double sum[] = new double[numSeries];
@@ -1133,7 +1253,12 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
                     classification = classifier.classifyInstance(classifier.subsampleIndices.indexOf(test));
                 }
                 else{
-                    classification = classifier.classifyInstance(train.get(test));
+                    if (fullTrainCVEstimate){
+                        classification = classifier.classifyInstance(train.get(test));
+                    }
+                    else{
+                        continue;
+                    }
                 }
 
                 classHist[n][(int) classification] += classifier.weight;
@@ -1141,12 +1266,17 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
             }
         }
 
-        double[] distributions = new double[numclasses];
+        double[] distributions = new double[numClasses];
 
         for (int n = 0; n < numSeries; n++){
-            if (sum[n] != 0)
+            if (sum[n] != 0) {
                 for (int i = 0; i < classHist[n].length; ++i)
                     distributions[i] += (classHist[n][i] / sum[n]) / numSeries;
+            }
+            else{
+                for (int i = 0; i < classHist[n].length; ++i)
+                    distributions[i] += (1 / numClasses) / numSeries;
+            }
         }
 
         return distributions;
@@ -1257,6 +1387,7 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
         c.useRecommendedSettingsRBOSS();
         c.bayesianParameterSelection = false;
         c.setSeed(fold);
+        c.setFindTrainAccuracyEstimate(true);
         c.buildClassifier(train);
         accuracy = ClassifierTools.accuracy(test, c);
 
@@ -1266,6 +1397,7 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
         c.useRecommendedSettingsRBOSS();
         c.bayesianParameterSelection = false;
         c.setSeed(fold);
+        c.setFindTrainAccuracyEstimate(true);
         c.buildClassifier(train2);
         accuracy = ClassifierTools.accuracy(test2, c);
 
@@ -1344,6 +1476,7 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
         c.setCleanupCheckpointFiles(true);
         c.setSavePath("D:\\");
         c.setSeed(fold);
+        c.setFindTrainAccuracyEstimate(true);
         c.buildClassifier(train);
         accuracy = ClassifierTools.accuracy(test, c);
 
@@ -1354,6 +1487,7 @@ public class RBOSS extends AbstractClassifierWithTrainingInfo implements TrainAc
         c.setCleanupCheckpointFiles(true);
         c.setSavePath("D:\\");
         c.setSeed(fold);
+        c.setFindTrainAccuracyEstimate(true);
         c.buildClassifier(train2);
         accuracy = ClassifierTools.accuracy(test2, c);
 

--- a/src/main/java/timeseriesweka/classifiers/interval_based/TSF.java
+++ b/src/main/java/timeseriesweka/classifiers/interval_based/TSF.java
@@ -15,15 +15,8 @@
 package timeseriesweka.classifiers.interval_based;
 
 import fileIO.OutFile;
-
-import java.io.*;
-import java.security.InvalidParameterException;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.Random;
-
-import timeseriesweka.classifiers.*;
-import timeseriesweka.classifiers.dictionary_based.BOSSIndividual;
 import utilities.ClassifierTools;
 import evaluation.evaluators.CrossValidationEvaluator;
 import weka.classifiers.AbstractClassifier;
@@ -35,10 +28,11 @@ import weka.core.Instances;
 import weka.core.TechnicalInformation;
 import evaluation.storage.ClassifierResults;
 import experiments.data.DatasetLoading;
-
+import java.io.File;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
-
+import timeseriesweka.classifiers.AbstractClassifierWithTrainingInfo;
+import timeseriesweka.classifiers.SaveParameterInfo;
 import weka.classifiers.Classifier;
 import weka.classifiers.meta.Bagging;
 import weka.core.Capabilities;
@@ -46,99 +40,99 @@ import weka.core.Capabilities.Capability;
 import weka.core.Randomizable;
 import weka.core.TechnicalInformationHandler;
 import weka.core.Utils;
+import timeseriesweka.classifiers.TrainAccuracyEstimator;
 
-/**
- <!-- globalinfo-start -->
- * Implementation of Time Series Forest
- Time Series Forest (TimeSeriesForest) Deng 2013:
- * buildClassifier
+/** 
+  <!-- globalinfo-start -->
+* Implementation of Time Series Forest
+ Time Series Forest (TimeSeriesForest) Deng 2013: 
+* buildClassifier
  * Overview: Input n series length m
  * for each tree
  *      sample sqrt(m) intervals
  *      find three features on each interval: mean, standard deviation and slope
  *      concatenate to new feature set
  *      build tree on new feature set
- * classifyInstance
- *   ensemble the trees with majority vote
+* classifyInstance
+*   ensemble the trees with majority vote
 
- * This implementation may deviate from the original, as it is using the same
- * structure as the weka random forest. In the paper the splitting criteria has a
- * tiny refinement. Ties in entropy gain are split with a further stat called margin
- * that measures the distance of the split point to the closest data.
- * So if the split value for feature
- * f=f_1,...f_n is v the margin is defined as
- *   margin= min{ |f_i-v| }
- * for simplicity of implementation, and for the fact when we did try it and it made
- * no difference, we have not used this. Note also, the original R implementation
- * may do some sampling of cases
+* This implementation may deviate from the original, as it is using the same
+* structure as the weka random forest. In the paper the splitting criteria has a 
+* tiny refinement. Ties in entropy gain are split with a further stat called margin 
+* that measures the distance of the split point to the closest data. 
+* So if the split value for feature 
+* f=f_1,...f_n is v the margin is defined as
+*   margin= min{ |f_i-v| } 
+* for simplicity of implementation, and for the fact when we did try it and it made 
+* no difference, we have not used this. Note also, the original R implementation 
+* may do some sampling of cases
 
- * Update 1:
- * * A few changes made to enable testing refinements.
- *1. general baseClassifier rather than a hard coded RandomTree. We tested a few
- *  alternatives, the summary results are available at
- *  http://www.timeseriesclassification.com/Experiments/TSF.xlsx
- *  Summary:
- *  Base Classifier:
- *       a) C.45 (J48) significantly worse than random tree
- *       b) CAWPE tbc
- *       c) CART tbc
- * 2. Added setOptions to allow parameter tuning. Tuning on parameters
- *       #trees, #features
+* Update 1:
+* * A few changes made to enable testing refinements. 
+*1. general baseClassifier rather than a hard coded RandomTree. We tested a few 
+*  alternatives, the summary results are available at
+*  http://www.timeseriesclassification.com/Experiments/TSF.xlsx
+*  Summary:
+*  Base Classifier: 
+*       a) C.45 (J48) significantly worse than random tree 
+*       b) CAWPE tbc
+*       c) CART tbc
+* 2. Added setOptions to allow parameter tuning. Tuning on parameters
+*       #trees, #features 
  <!-- globalinfo-end -->
  <!-- technical-bibtex-start -->
- * Bibtex
- * <pre>
- * @article{deng13forest,
- * author = {H. Deng and G. Runger and E. Tuv and M. Vladimir},
- * title = {A time series forest for classification and feature extraction},
- * journal = {Information Sciences},
- * volume = {239},
- * year = {2013}
- *}
+* Bibtex
+* <pre>
+* @article{deng13forest,
+* author = {H. Deng and G. Runger and E. Tuv and M. Vladimir},
+* title = {A time series forest for classification and feature extraction},
+* journal = {Information Sciences},
+* volume = {239},
+* year = {2013}
+*}
 </pre>
 <!-- technical-bibtex-end -->
-<!-- options-start -->
+ <!-- options-start -->
  * Valid options are: <p/>
- *
+ * 
  * <pre> -T
  *  set number of trees in the ensemble.</pre>
- *
+ * 
  * <pre> -I
  *  set number of intervals to calculate.</pre>
-<!-- options-end -->
+ <!-- options-end -->
 
- * @author ajb
- * @date 7/10/15
- * @update1 14/2/19
+* @author ajb
+* @date 7/10/15
+* @update1 14/2/19
 
- **/
+**/ 
 
-public class TSF extends AbstractClassifierWithTrainingInfo
-        implements SaveParameterInfo, TrainAccuracyEstimator, Randomizable,TechnicalInformationHandler,
-        TrainTimeContractable, Checkpointable {
+public class TSF extends AbstractClassifierWithTrainingInfo 
+        implements SaveParameterInfo, TrainAccuracyEstimator, Randomizable,TechnicalInformationHandler{
 //Static defaults
-
+    
     private final static int DEFAULT_NUM_CLASSIFIERS=500;
 
-    /** Primary parameters potentially tunable*/
+    /** Primary parameters potentially tunable*/    
     private int numClassifiers=DEFAULT_NUM_CLASSIFIERS;
 
-    /** numIntervalsFinder sets numIntervals in buildClassifier. */
+    /** numIntervalsFinder sets numIntervals in buildClassifier. */    
     private int numIntervals=0;
-    Function<Integer,Integer> numIntervalsFinder = (numAtts) -> (int)(Math.sqrt(numAtts));
-    /** Secondary parameter, mainly there to avoid single item intervals,
+    Function<Integer,Integer> numIntervalsFinder = (numAtts) -> (int)(Math.sqrt(numAtts));   
+    /** Secondary parameter, mainly there to avoid single item intervals, 
      which have no slope or std dev*/
     private int minIntervalLength=3;
 
     /** Ensemble members of base classifier, default to random forest RandomTree */
-    private ArrayList<Classifier> trees;
+    private Classifier[] trees; 
     private Classifier base= new RandomTree();
 
-    /** for each classifier [i]  interval j  starts at intervals[i][j][0] and
+    /** for each classifier [i]  interval j  starts at intervals[i][j][0] and 
      ends  at  intervals[i][j][1] */
-    private ArrayList<int[][]> intervals;
-
-    /**Holding variable for test classification in order to retain the header info*/
+    private int[][][] intervals;
+    
+    /**Holding variable for test classification in order to retain the header info*/     
     private Instances testHolder;
 
     /**Can seed for reproducibility*/
@@ -146,31 +140,23 @@ public class TSF extends AbstractClassifierWithTrainingInfo
     private boolean setSeed=false;
     private int seed=0;
 
-    /** If trainAccuracy is required, a cross validation is done in buildClassifier
-     * or a OOB estimate is formed
-     If set, train results are overwritten with each call to buildClassifier
-     File opened on this path.*/
-    boolean trainAccuracyEst=false;
+   /** If trainAccuracy is required, a cross validation is done in buildClassifier
+    * or a OOB estimate is formed
+   If set, train results are overwritten with each call to buildClassifier
+   File opened on this path.*/     
+    boolean trainAccuracyEst=false;  
     private String trainCVPath="";
-
+    
     /** voteEnsemble determines whether to aggregate classifications or
      * probabilities when predicting */
     private boolean voteEnsemble=true;
-
-    /** Flags and data required if Bagging **/
+    
+ /** Flags and data required if Bagging **/   
     private boolean bagging=false; //Use if we want an OOB estimate
-    private ArrayList<boolean[]> inBag;
+    private boolean[][] inBag;
     private int[] oobCounts;
     private double[][] trainDistributions;
-
-    private boolean checkpoint = false;
-    private String checkpointPath;
-    private long checkpointTime = 0;
-    private long checkpointTimeElapsed= 0;
-
-    private boolean trainTimeContract = false;
-    private long contractTime = 0;
-
+    
     public TSF(){
         rand=new Random();
     }
@@ -180,10 +166,10 @@ public class TSF extends AbstractClassifierWithTrainingInfo
         rand.setSeed(seed);
         setSeed=true;
     }
-    /**
-     *
-     * @param c a base classifier constructed elsewhere and cloned into ensemble
-     */
+/**
+ * 
+ * @param c a base classifier constructed elsewhere and cloned into ensemble
+ */    
     public void setBaseClassifier(Classifier c){
         base=c;
     }
@@ -191,21 +177,21 @@ public class TSF extends AbstractClassifierWithTrainingInfo
         bagging=b;
     }
 
-    /**
-     * ok,  two methods are a bit pointless, experimenting with ensemble method
-     * @param b
-     */
+/**
+ * ok,  two methods are a bit pointless, experimenting with ensemble method
+ * @param b 
+ */    
     public void setVoteEnsemble(boolean b){
         voteEnsemble=b;
     }
     public void setProbabilityEnsemble(boolean b){
         voteEnsemble=!b;
     }
-
-    /**
-     * Seed experiments for reproducibility with the resample number
-     * @param s
-     */
+    
+/**
+ * Seed experiments for reproducibility with the resample number
+ * @param s 
+ */    
     @Override
     public void setSeed(int s){
         this.setSeed=true;
@@ -213,108 +199,108 @@ public class TSF extends AbstractClassifierWithTrainingInfo
         rand=new Random();
         rand.setSeed(seed);
     }
-    /**
-     * Stores the classifier train CV results and writes them to file.
-     * boolean trainCV is a little redundant, but nicer than checking path for null
-     * @param train
-     */
+/**
+ * Stores the classifier train CV results and writes them to file. 
+ * boolean trainCV is a little redundant, but nicer than checking path for null
+ * @param train 
+ */    
     @Override
     public void writeTrainEstimatesToFile(String train) {
         trainCVPath=train;
         trainAccuracyEst=true;
     }
-    /**
-     * We can perform trainCV without writing the results to file. The could be used,
-     * for example, in an ensemble this TSF is a member of
-     * @param setCV
-     */
+/**
+ * We can perform trainCV without writing the results to file. The could be used,
+ * for example, in an ensemble this TSF is a member of
+ * @param setCV 
+ */
     @Override
     public void setFindTrainAccuracyEstimate(boolean setCV){
         trainAccuracyEst=setCV;
     }
-    /**
-     * Maybe this method needs renaming?
-     * @return boolean, whether trainCV happens or not
-     */
+/** 
+ * Maybe this method needs renaming?
+ * @return boolean, whether trainCV happens or not
+ */    
     @Override
     public boolean findsTrainAccuracyEstimate(){ return trainAccuracyEst;}
-
-    /**
-     *
-     * @return a ClassifierResults object, which will be null if tainCV is null
-     */
+    
+/**
+ * 
+ * @return a ClassifierResults object, which will be null if tainCV is null
+ */    
     @Override
-    public ClassifierResults getTrainResults(){
-        return trainResults;
-    }
-    /**
-     * Perhaps make this coherent with setOptions(String[] ar)?
-     * @return String written to results files
-     */
+     public ClassifierResults getTrainResults(){
+         return trainResults;
+     }        
+/**
+ * Perhaps make this coherent with setOptions(String[] ar)?
+ * @return String written to results files
+ */
     @Override
     public String getParameters() {
         String temp=super.getParameters()+",numTrees,"+numClassifiers+",numIntervals,"+numIntervals+",voting,"+voteEnsemble+",BaseClassifier,"+base.getClass().getSimpleName()+",Bagging,"+bagging;
         if(base instanceof RandomTree)
-            temp+=",AttsConsideredPerNode,"+((RandomTree)base).getKValue();
+           temp+=",AttsConsideredPerNode,"+((RandomTree)base).getKValue();
         return temp;
 
     }
     public void setNumTrees(int t){
         numClassifiers=t;
     }
-
-
-    //<editor-fold defaultstate="collapsed" desc="results reported in Info Sciences paper">
+    
+    
+//<editor-fold defaultstate="collapsed" desc="results reported in Info Sciences paper">        
     static double[] reportedResults={
-            0.2659,
-            0.2302,
-            0.2333,
-            0.0256,
-            0.2537,
-            0.0391,
-            0.0357,
-            0.2897,
-            0.2,
-            0.2436,
-            0.049,
-            0.08,
-            0.0557,
-            0.2325,
-            0.0227,
-            0.101,
-            0.1543,
-            0.0467,
-            0.552,
-            0.6818,
-            0.0301,
-            0.1803,
-            0.2603,
-            0.0448,
-            0.2237,
-            0.119,
-            0.0987,
-            0.0865,
-            0.0667,
-            0.4339,
-            0.233,
-            0.1868,
-            0.0357,
-            0.1056,
-            0.1116,
-            0.0267,
-            0.02,
-            0.1177,
-            0.0543,
-            0.2102,
-            0.2876,
-            0.2624,
-            0.0054,
-            0.3793,
-            0.1513
+        0.2659,
+        0.2302,
+        0.2333,
+        0.0256,
+        0.2537,
+        0.0391,
+        0.0357,
+        0.2897,
+        0.2,
+        0.2436,
+        0.049,
+        0.08,
+        0.0557,
+        0.2325,
+        0.0227,
+        0.101,
+        0.1543,
+        0.0467,
+        0.552,
+        0.6818,
+        0.0301,
+        0.1803,
+        0.2603,
+        0.0448,
+        0.2237,
+        0.119,
+        0.0987,
+        0.0865,
+        0.0667,
+        0.4339,
+        0.233,
+        0.1868,
+        0.0357,
+        0.1056,
+        0.1116,
+        0.0267,
+        0.02,
+        0.1177,
+        0.0543,
+        0.2102,
+        0.2876,
+        0.2624,
+        0.0054,
+        0.3793,
+        0.1513
     };
-    //</editor-fold>
-
-    //<editor-fold defaultstate="collapsed" desc="problems used in Info Sciences paper">
+      //</editor-fold>  
+    
+//<editor-fold defaultstate="collapsed" desc="problems used in Info Sciences paper">   
     static String[] problems={
             "FiftyWords",
             "Adiac",
@@ -361,13 +347,13 @@ public class TSF extends AbstractClassifierWithTrainingInfo
             "Wafer",
             "WordsSynonyms",
             "Yoga"
-    };
-    //</editor-fold>
-
-    /**
-     * paper defining TSF
-     * @return TechnicalInformation
-     */
+        };
+      //</editor-fold>  
+ 
+ /**
+  * paper defining TSF
+  * @return TechnicalInformation
+  */   
     @Override
     public TechnicalInformation getTechnicalInformation() {
         TechnicalInformation 	result;
@@ -380,64 +366,36 @@ public class TSF extends AbstractClassifierWithTrainingInfo
         result.setValue(TechnicalInformation.Field.PAGES, "142-153");
 
         return result;
-    }
+  }
+    
 
-
-    /**
-     * main buildClassifier
-     * @param data
-     * @throws Exception
-     */
+/**
+ * main buildClassifier
+ * @param data
+ * @throws Exception 
+ */      
     @Override
     public void buildClassifier(Instances data) throws Exception {
-        // can classifier handle the data?
+    // can classifier handle the data?
         getCapabilities().testWithFail(data);
         long t1=System.nanoTime();
-
-        //path checkpoint files will be saved to
-        File file = new File(checkpointPath + "TSF" + seed + ".ser");
-
-        //if checkpointing and serialised files exist load said files
-        if (checkpoint && file.exists()){
-            loadFromFile(checkpointPath + "TSF" + seed + ".ser");
-        }
-        //initialise variables
-        else {
-            numIntervals=numIntervalsFinder.apply(data.numAttributes()-1);
-            //Estimate train accuracy here if required and not using bagging
-//Set up instances size and format.
-            trees=new ArrayList(numClassifiers);
-
-            /** Set up for train rstimate **/
-            if(trainAccuracyEst) {
-                trainDistributions= new double[data.numInstances()][data.numClasses()];
-            }
-
-            /** Set up for Bagging **/
-            if(bagging){
-                inBag=new ArrayList();
-                oobCounts=new int[data.numInstances()];
-            }
-
-            //cancel loop using time instead of number built.
-            if (trainTimeContract){
-                numClassifiers = 0;
-            }
-        }
-
+        numIntervals=numIntervalsFinder.apply(data.numAttributes()-1);
+    //Estimate train accuracy here if required and not using bagging
+//Set up instances size and format. 
+        trees=new AbstractClassifier[numClassifiers];        
         ArrayList<Attribute> atts=new ArrayList<>();
         String name;
         for(int j=0;j<numIntervals*3;j++){
             name = "F"+j;
             atts.add(new Attribute(name));
         }
-        //Get the class values as an array list
+        //Get the class values as an array list		
         Attribute target =data.attribute(data.classIndex());
         ArrayList<String> vals=new ArrayList<>(target.numValues());
         for(int j=0;j<target.numValues();j++)
             vals.add(target.value(j));
         atts.add(new Attribute(data.attribute(data.classIndex()).name(),vals));
-        //create blank instances with the correct class value
+        //create blank instances with the correct class value                
         Instances result = new Instances("Tree",atts,data.numInstances());
         result.setClassIndex(result.numAttributes()-1);
         for(int i=0;i<data.numInstances();i++){
@@ -445,138 +403,96 @@ public class TSF extends AbstractClassifierWithTrainingInfo
             in.setValue(result.numAttributes()-1,data.instance(i).classValue());
             result.add(in);
         }
-
-        testHolder =new Instances(result,0);
+        
+        testHolder =new Instances(result,0);       
         DenseInstance in=new DenseInstance(result.numAttributes());
         testHolder.add(in);
 //Need to hard code this because log(m)+1 is sig worse than sqrt(m) is worse than using all!
         if(base instanceof RandomTree){
             ((RandomTree) base).setKValue(result.numAttributes()-1);
 //            ((RandomTree) base).setKValue((int)Math.sqrt(result.numAttributes()-1));
+        }        
+        /** Set up for Bagging **/
+        if(bagging){
+           inBag=new boolean[numClassifiers][];
+           trainDistributions= new double[data.numInstances()][data.numClasses()];
+           oobCounts=new int[data.numInstances()];
         }
-
-        int classifiersBuilt = trees.size();
-
-        /** For each base classifier
+        
+        /** For each base classifier 
          *      generate random intervals
          *      do the transfrorms
          *      build the classifier
          * */
-        intervals = new ArrayList();
-        while((System.nanoTime()-t1)+checkpointTimeElapsed < contractTime || classifiersBuilt < numClassifiers){
-            //1. Select random intervals for tree i
-            int[][] interval =new int[numIntervals][2];  //Start and end
+        intervals =new int[numClassifiers][][];
+        for(int i=0;i<numClassifiers;i++){
+        //1. Select random intervals for tree i
+            intervals[i]=new int[numIntervals][2];  //Start and end
             if(data.numAttributes()-1<minIntervalLength)
-                minIntervalLength=data.numAttributes()-1;
+                 minIntervalLength=data.numAttributes()-1;
             for(int j=0;j<numIntervals;j++){
-                interval[j][0]=rand.nextInt(data.numAttributes()-1-minIntervalLength);       //Start point
-                int length=rand.nextInt(data.numAttributes()-1-interval[j][0]);//Min length 3
-                if(length<minIntervalLength)
-                    length=minIntervalLength;
-                interval[j][1]=interval[j][0]+length;
+               intervals[i][j][0]=rand.nextInt(data.numAttributes()-1-minIntervalLength);       //Start point
+               int length=rand.nextInt(data.numAttributes()-1-intervals[i][j][0]);//Min length 3
+               if(length<minIntervalLength)
+                   length=minIntervalLength;
+               intervals[i][j][1]=intervals[i][j][0]+length;
             }
-            //2. Generate and store attributes
+        //2. Generate and store attributes            
             for(int j=0;j<numIntervals;j++){
                 //For each instance
                 for(int k=0;k<data.numInstances();k++){
                     //extract the interval
                     double[] series=data.instance(k).toDoubleArray();
                     FeatureSet f= new FeatureSet();
-                    f.setFeatures(series, interval[j][0], interval[j][1]);
+                    f.setFeatures(series, intervals[i][j][0], intervals[i][j][1]);
                     result.instance(k).setValue(j*3, f.mean);
                     result.instance(k).setValue(j*3+1, f.stDev);
                     result.instance(k).setValue(j*3+2, f.slope);
                 }
             }
-            //3. Create and build tree using all the features. Feature selection
-            Classifier tree = AbstractClassifier.makeCopy(base);
-            if(setSeed && tree instanceof Randomizable)
-                ((Randomizable)tree).setSeed(seed*(classifiersBuilt+1));
+        //3. Create and build tree using all the features. Feature selection
+            trees[i]=AbstractClassifier.makeCopy(base); 
+            if(setSeed && trees[i] instanceof Randomizable)
+                ((Randomizable)trees[i]).setSeed(seed*(i+1));
             if(bagging){
-                boolean[] bag = new boolean[result.numInstances()];
-                Instances bagData = result.resampleWithWeights(rand, bag);
-                tree.buildClassifier(bagData);
+                inBag[i] = new boolean[result.numInstances()];
+                Instances bagData = result.resampleWithWeights(rand, inBag[i]);
+                trees[i].buildClassifier(bagData);
                 if(trainAccuracyEst){
                     for(int j=0;j<result.numInstances();j++){
-                        if(bag[j])
+                        if(inBag[i][j])
                             continue;
-                        double[] newProbs = tree.distributionForInstance(result.instance(j));
+                        double[] newProbs = trees[i].distributionForInstance(result.instance(j));
                         oobCounts[j]++;
                         for(int k=0;k<newProbs.length;k++)
                             trainDistributions[j][k]+=newProbs[k];
-
-                    }
-                }
-                inBag.add(bag);
-            }
-            else{
-                tree.buildClassifier(result);
-
-                if(trainAccuracyEst) {
-                    /** Defaults to 10 or numInstances, whichever is smaller.
-                     * Interface TrainAccuracyEstimate
-                     * Could this be handled better? */
-                    int numFolds = setNumberOfFolds(data);
-                    CrossValidationEvaluator cv = new CrossValidationEvaluator();
-                    if (setSeed)
-                        cv.setSeed(seed);
-                    cv.setNumFolds(numFolds);
-                    ClassifierResults results = cv.crossValidateWithStats(AbstractClassifier.makeCopy(base), result);
-
-                    for (int j = 0; j < result.numInstances(); j++) {
-                        double[] newProbs = results.getProbabilityDistribution(j);
-                        for (int k = 0; k < newProbs.length; k++)
-                            trainDistributions[j][k] += newProbs[k];
+                        
                     }
                 }
             }
-
-            intervals.add(interval);
-            trees.add(tree);
-            classifiersBuilt++;
-
-            if (checkpoint){
-                checkpoint(t1);
-            }
+            else
+                trees[i].buildClassifier(result);
         }
-
+        
         long t2=System.nanoTime();
         //Store build time, this is always recorded
-        trainResults.setBuildTime((t2-t1)+checkpointTimeElapsed);
-        //If trainAccuracyEst ==true and we want to save results, write out object
+        trainResults.setBuildTime(t2-t1);
+        //If trainAccuracyEst ==true and we want to save results, write out object 
         if(trainAccuracyEst){
-            if(!bagging){//Do a CV
-                double[] preds=new double[data.numInstances()];
-                double[] actuals=new double[data.numInstances()];
-                for(int j=0;j<data.numInstances();j++){
-                    for(int k=0;k<trainDistributions[j].length;k++)
-                        trainDistributions[j][k]/=trees.size();
-                    preds[j]=utilities.GenericTools.indexOfMax(trainDistributions[j]);
-                    actuals[j]=data.instance(j).classValue();
-                }
-                long[] predTimes=new long[data.numInstances()];//Dummy variable, need something
-                trainResults.addAllPredictions(preds, trainDistributions, predTimes, null);
-                trainResults.setTimeUnit(TimeUnit.NANOSECONDS);
-                trainResults.setClassifierName("TSF");
-                trainResults.setDatasetName(data.relationName());
-                trainResults.setSplit("train");
-                trainResults.setFoldID(seed);
-                trainResults.setParas(getParameters());
-                trainResults.finaliseResults(actuals);
-
-//                /** Defaults to 10 or numInstances, whichever is smaller.
-//                 * Interface TrainAccuracyEstimate
-//                 * Could this be handled better? */
-//                int numFolds=setNumberOfFolds(data);
-//                CrossValidationEvaluator cv = new CrossValidationEvaluator();
-//                if (setSeed)
-//                    cv.setSeed(seed);
-//                cv.setNumFolds(numFolds);
-//                TSF tsf=new TSF();
-//                tsf.setFindTrainAccuracyEstimate(false);
-//                trainResults=cv.crossValidateWithStats(tsf,data);
-            }else{
-                // Use bag data. Normalise probs
+             if(!bagging){//Do a CV
+                /** Defaults to 10 or numInstances, whichever is smaller. 
+                 * Interface TrainAccuracyEstimate
+                 * Could this be handled better? */
+                int numFolds=setNumberOfFolds(data);
+                CrossValidationEvaluator cv = new CrossValidationEvaluator();
+                if (setSeed)
+                  cv.setSeed(seed);
+                cv.setNumFolds(numFolds);
+                TSF tsf=new TSF();
+                tsf.setFindTrainAccuracyEstimate(false);
+                trainResults=cv.crossValidateWithStats(tsf,data);
+             }else{
+            // Use bag data. Normalise probs
                 double[] preds=new double[data.numInstances()];
                 double[] actuals=new double[data.numInstances()];
                 for(int j=0;j<data.numInstances();j++){
@@ -594,7 +510,7 @@ public class TSF extends AbstractClassifierWithTrainingInfo
                 trainResults.setFoldID(seed);
                 trainResults.setParas(getParameters());
                 trainResults.finaliseResults(actuals);
-            }
+             }
             if(trainCVPath!=""){
                 trainResults.writeFullResultsToFile(trainCVPath);
 /*                OutFile of=new OutFile(trainCVPath);
@@ -614,36 +530,36 @@ public class TSF extends AbstractClassifierWithTrainingInfo
                        of.writeString(","+d);
                    of.writeString("\n");
                }
-*/
-            }
+*/                
+           }
         }
-
+        
     }
-    /**
-     * Sums either the
-     * @param ins to classifier
-     * @return array of doubles: probability of each class
-     * @throws Exception
-     */
+/**
+ * Sums either the 
+ * @param ins to classifier
+ * @return array of doubles: probability of each class 
+ * @throws Exception 
+ */    
     @Override
     public double[] distributionForInstance(Instance ins) throws Exception {
         double[] d=new double[ins.numClasses()];
         //Build transformed instance
         double[] series=ins.toDoubleArray();
-        for(int i=0;i<trees.size();i++){
+        for(int i=0;i<trees.length;i++){
             for(int j=0;j<numIntervals;j++){
                 //extract all intervals
                 FeatureSet f= new FeatureSet();
-                f.setFeatures(series, intervals.get(i)[j][0], intervals.get(i)[j][1]);
+                f.setFeatures(series, intervals[i][j][0], intervals[i][j][1]);
                 testHolder.instance(0).setValue(j*3, f.mean);
                 testHolder.instance(0).setValue(j*3+1, f.stDev);
                 testHolder.instance(0).setValue(j*3+2, f.slope);
             }
             if(voteEnsemble){
-                int c=(int)trees.get(i).classifyInstance(testHolder.instance(0));
+                int c=(int)trees[i].classifyInstance(testHolder.instance(0));
                 d[c]++;
             }else{
-                double[] temp=trees.get(i).distributionForInstance(testHolder.instance(0));
+                double[] temp=trees[i].distributionForInstance(testHolder.instance(0));
                 for(int j=0;j<temp.length;j++)
                     d[j]+=temp[j];
             }
@@ -655,12 +571,12 @@ public class TSF extends AbstractClassifierWithTrainingInfo
             d[i]=d[i]/sum;
         return d;
     }
-    /**
-     * What about
-     * @param ins
-     * @return
-     * @throws Exception
-     */
+/**
+ * What about  
+ * @param ins
+ * @return
+ * @throws Exception 
+ */
     @Override
     public double classifyInstance(Instance ins) throws Exception {
         double[] d=distributionForInstance(ins);
@@ -670,37 +586,37 @@ public class TSF extends AbstractClassifierWithTrainingInfo
                 max=i;
         return (double)max;
     }
-    /**
-     * Parses a given list of options to set the parameters of the classifier.
-     * We use this for the tuning mechanism, setting parameters through setOptions
-     <!-- options-start -->
-     * Valid options are: <p/>
-     * <pre> -T
-     * Number of trees.</pre>
-     *
-     * <pre> -I
-     * Number of intervals to fit.</pre>
-     *
-     <!-- options-end -->
-     *
-     * @param options the list of options as an array of strings
-     * @throws Exception if an option is not supported
-     */
+  /**
+   * Parses a given list of options to set the parameters of the classifier.
+   * We use this for the tuning mechanism, setting parameters through setOptions 
+   <!-- options-start -->
+   * Valid options are: <p/>
+   * <pre> -T
+   * Number of trees.</pre>
+   * 
+   * <pre> -I
+   * Number of intervals to fit.</pre>
+   * 
+   <!-- options-end -->
+   *
+   * @param options the list of options as an array of strings
+   * @throws Exception if an option is not supported
+   */
     @Override
     public void setOptions(String[] options) throws Exception{
         System.out.print("TSF para sets ");
         for (String str:options)
-            System.out.print(","+str);
+             System.out.print(","+str);
         System.out.print("\n");
         String numTreesString=Utils.getOption('T', options);
         if (numTreesString.length() != 0)
             numClassifiers = Integer.parseInt(numTreesString);
         else
             numClassifiers = DEFAULT_NUM_CLASSIFIERS;
-
+        
         String numFeaturesString=Utils.getOption('I', options);
-//Options here are a double between 0 and 1 (proportion of features), a text
-//string sqrt or log, or an integer number
+//Options here are a double between 0 and 1 (proportion of features), a text 
+//string sqrt or log, or an integer number 
         if (numTreesString.length() != 0){
             try{
                 if(numFeaturesString.equals("sqrt"))
@@ -708,16 +624,16 @@ public class TSF extends AbstractClassifierWithTrainingInfo
                 else if(numFeaturesString.equals("log"))
                     numIntervalsFinder = (numAtts) -> (int) Utils.log2(numAtts) + 1;
                 else{
-                    double d=Double.parseDouble(numFeaturesString);
-                    if(d<=0)
-                        throw new Exception("proportion of features of of range 0 to 1");
-                    if(d<=1)
-                        numIntervalsFinder = (numAtts) -> (int)(d*numAtts);
-                    else
-                        numIntervalsFinder = (numAtts) -> (int)(d);
+                        double d=Double.parseDouble(numFeaturesString);
+                        if(d<=0)
+                            throw new Exception("proportion of features of of range 0 to 1");
+                        if(d<=1)
+                            numIntervalsFinder = (numAtts) -> (int)(d*numAtts);
+                        else
+                            numIntervalsFinder = (numAtts) -> (int)(d);
 
 //                        System.out.println("Proportion/number of intervals = "+d);
-                }
+                 }
             }catch(Exception e){
                 System.err.print(" Error: invalid parameter passed to TSF setOptions for number of parameters. Setting to default");
                 System.err.print("Value"+numIntervalsFinder+" Permissable values: sqrt, log, or a double range 0...1");
@@ -733,99 +649,7 @@ public class TSF extends AbstractClassifierWithTrainingInfo
         return seed;
     }
 
-    @Override
-    public void setSavePath(String path) {
-        checkpointPath = path;
-        checkpoint = true;
-    }
-
-    @Override
-    public void copyFromSerObject(Object obj) throws Exception {
-        if(!(obj instanceof TSF))
-            throw new Exception("The SER file is not an instance of TSF");
-        TSF saved = ((TSF)obj);
-        System.out.println("Loading TSF" + seed + ".ser");
-
-        try{
-            numClassifiers = saved.numClassifiers;
-            numIntervals = saved.numIntervals;
-            //numIntervalsFinder = saved.numIntervalsFinder;
-            minIntervalLength = saved.minIntervalLength;
-            trees = saved.trees;
-            base = saved.base;
-            intervals = saved.intervals;
-            //testHolder = saved.testHolder;
-            rand = saved.rand;
-            setSeed = saved.setSeed;
-            seed = saved.seed;
-            trainAccuracyEst = saved.trainAccuracyEst;
-            trainCVPath = saved.trainCVPath;
-            voteEnsemble = saved.voteEnsemble;
-            bagging = saved.bagging;
-            inBag = saved.inBag;
-            oobCounts = saved.oobCounts;
-            trainDistributions = saved.trainDistributions;
-            //checkpoint = saved.checkpoint;
-            //checkpointPath = saved.checkpointPath
-            checkpointTime = checkpointTimeElapsed;
-            checkpointTimeElapsed = saved.checkpointTimeElapsed;
-            trainTimeContract = saved.trainTimeContract;
-            contractTime = saved.contractTime;
-        }catch(Exception ex){
-            System.out.println("Unable to assign variables when loading serialised file");
-        }
-    }
-
-    @Override
-    public void setTrainTimeLimit(TimeUnit time, long amount) {
-        switch (time){
-            case DAYS:
-                contractTime = (long)(8.64e+13)*amount;
-                break;
-            case HOURS:
-                contractTime = (long)(3.6e+12)*amount;
-                break;
-            case MINUTES:
-                contractTime = (long)(6e+10)*amount;
-                break;
-            case SECONDS:
-                contractTime = (long)(1e+9)*amount;
-                break;
-            case NANOSECONDS:
-                contractTime = amount;
-                break;
-            default:
-                throw new InvalidParameterException("Invalid time unit");
-        }
-        trainTimeContract = true;
-    }
-
-    private void checkpoint(long startTime){
-        if(checkpointPath!=null){
-            try{
-                File f = new File(checkpointPath);
-                if(!f.isDirectory())
-                    f.mkdirs();
-
-                //time spent building so far.
-                checkpointTimeElapsed += ((System.nanoTime() - startTime) + checkpointTime);
-
-                //save this, classifiers and train data not included
-                saveToFile(checkpointPath + "TSFtemp.ser");
-
-                File file = new File(checkpointPath + "TSFtemp.ser");
-                File file2 = new File(checkpointPath + "TSF.ser");
-                file2.delete();
-                file.renameTo(file2);
-            }
-            catch(Exception e){
-                e.printStackTrace();
-                System.out.println("Serialisation to "+checkpointPath+" FAILED");
-            }
-        }
-    }
-
-    //Nested class to store three simple summary features used to construct train data
+//Nested class to store three simple summary features used to construct train data
     public static class FeatureSet{
         public static boolean findSkew=false;
         public static boolean findKurtosis=false;
@@ -881,7 +705,7 @@ public class TSF extends AbstractClassifierWithTrainingInfo
                     skew/=length*stDev*stDev*stDev*stDev;
                 }
             }
-
+            
         }
         public void setFeatures(double[] data){
             setFeatures(data,0,data.length-1);
@@ -890,11 +714,11 @@ public class TSF extends AbstractClassifierWithTrainingInfo
         public String toString(){
             return "mean="+mean+" stdev = "+stDev+" slope ="+slope;
         }
-    }
-
+    } 
+    
     public static void main(String[] arg) throws Exception{
 // Basic correctness tests, including setting paras through 
-        String dataLocation="C:\\Users\\ajb\\Dropbox\\TSC Problems\\";
+        String dataLocation="Z:\\Data\\TSCProblems2018\\";
         String resultsLocation="C:\\temp\\";
         String problem="ItalyPowerDemand";
         File f= new File(resultsLocation+problem);
@@ -903,6 +727,7 @@ public class TSF extends AbstractClassifierWithTrainingInfo
         Instances train=DatasetLoading.loadDataNullable(dataLocation+problem+"\\"+problem+"_TRAIN");
         Instances test=DatasetLoading.loadDataNullable(dataLocation+problem+"\\"+problem+"_TEST");
         TSF tsf = new TSF();
+        tsf.setSeed(0);
         tsf.writeTrainEstimatesToFile(resultsLocation+problem+"trainFold0.csv");
         double a;
         tsf.buildClassifier(train);
@@ -919,7 +744,8 @@ public class TSF extends AbstractClassifierWithTrainingInfo
         System.out.println("build ok: original atts="+(train.numAttributes()-1)+" new atts ="+tsf.testHolder.numAttributes()+" num trees = "+tsf.numClassifiers+" num intervals = "+tsf.numIntervals);
         a=ClassifierTools.accuracy(test, tsf);
         System.out.println("Test Accuracy ="+a);
-
-
+        
+        
     }
 }
+  

--- a/src/main/java/timeseriesweka/classifiers/interval_based/cTSF.java
+++ b/src/main/java/timeseriesweka/classifiers/interval_based/cTSF.java
@@ -1,0 +1,948 @@
+/*
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package timeseriesweka.classifiers.interval_based;
+
+import fileIO.OutFile;
+
+import java.io.*;
+import java.security.InvalidParameterException;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Random;
+
+import timeseriesweka.classifiers.*;
+import timeseriesweka.classifiers.dictionary_based.BOSSIndividual;
+import utilities.ClassifierTools;
+import evaluation.evaluators.CrossValidationEvaluator;
+import weka.classifiers.AbstractClassifier;
+import weka.classifiers.trees.RandomTree;
+import weka.core.Attribute;
+import weka.core.DenseInstance;
+import weka.core.Instance;
+import weka.core.Instances;
+import weka.core.TechnicalInformation;
+import evaluation.storage.ClassifierResults;
+import experiments.data.DatasetLoading;
+
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import weka.classifiers.Classifier;
+import weka.classifiers.meta.Bagging;
+import weka.core.Capabilities;
+import weka.core.Capabilities.Capability;
+import weka.core.Randomizable;
+import weka.core.TechnicalInformationHandler;
+import weka.core.Utils;
+
+/**
+ <!-- globalinfo-start -->
+ * Implementation of Time Series Forest
+ Time Series Forest (TimeSeriesForest) Deng 2013:
+ * buildClassifier
+ * Overview: Input n series length m
+ * for each tree
+ *      sample sqrt(m) intervals
+ *      find three features on each interval: mean, standard deviation and slope
+ *      concatenate to new feature set
+ *      build tree on new feature set
+ * classifyInstance
+ *   ensemble the trees with majority vote
+
+ * This implementation may deviate from the original, as it is using the same
+ * structure as the weka random forest. In the paper the splitting criteria has a
+ * tiny refinement. Ties in entropy gain are split with a further stat called margin
+ * that measures the distance of the split point to the closest data.
+ * So if the split value for feature
+ * f=f_1,...f_n is v the margin is defined as
+ *   margin= min{ |f_i-v| }
+ * for simplicity of implementation, and for the fact when we did try it and it made
+ * no difference, we have not used this. Note also, the original R implementation
+ * may do some sampling of cases
+
+ * Update 1:
+ * * A few changes made to enable testing refinements.
+ *1. general baseClassifier rather than a hard coded RandomTree. We tested a few
+ *  alternatives, the summary results are available at
+ *  http://www.timeseriesclassification.com/Experiments/TSF.xlsx
+ *  Summary:
+ *  Base Classifier:
+ *       a) C.45 (J48) significantly worse than random tree
+ *       b) CAWPE tbc
+ *       c) CART tbc
+ * 2. Added setOptions to allow parameter tuning. Tuning on parameters
+ *       #trees, #features
+ <!-- globalinfo-end -->
+ <!-- technical-bibtex-start -->
+ * Bibtex
+ * <pre>
+ * @article{deng13forest,
+ * author = {H. Deng and G. Runger and E. Tuv and M. Vladimir},
+ * title = {A time series forest for classification and feature extraction},
+ * journal = {Information Sciences},
+ * volume = {239},
+ * year = {2013}
+ *}
+</pre>
+<!-- technical-bibtex-end -->
+<!-- options-start -->
+ * Valid options are: <p/>
+ *
+ * <pre> -T
+ *  set number of trees in the ensemble.</pre>
+ *
+ * <pre> -I
+ *  set number of intervals to calculate.</pre>
+<!-- options-end -->
+
+ * @author ajb
+ * @date 7/10/15
+ * @update1 14/2/19
+
+ **/
+
+public class cTSF extends AbstractClassifierWithTrainingInfo
+        implements SaveParameterInfo, TrainAccuracyEstimator, Randomizable,TechnicalInformationHandler,
+        TrainTimeContractable, Checkpointable {
+//Static defaults
+
+    private final static int DEFAULT_NUM_CLASSIFIERS=500;
+
+    /** Primary parameters potentially tunable*/
+    private int numClassifiers=DEFAULT_NUM_CLASSIFIERS;
+
+    private int maxClassifiers = 1000;
+
+    /** numIntervalsFinder sets numIntervals in buildClassifier. */
+    private int numIntervals=0;
+    transient Function<Integer,Integer> numIntervalsFinder = (numAtts) -> (int)(Math.sqrt(numAtts));
+    /** Secondary parameter, mainly there to avoid single item intervals,
+     which have no slope or std dev*/
+    private int minIntervalLength=3;
+
+    /** Ensemble members of base classifier, default to random forest RandomTree */
+    private ArrayList<Classifier> trees;
+    private Classifier base= new RandomTree();
+
+    /** for each classifier [i]  interval j  starts at intervals[i][j][0] and
+     ends  at  intervals[i][j][1] */
+    private ArrayList<int[][]> intervals;
+
+    /**Holding variable for test classification in order to retain the header info*/
+    private Instances testHolder;
+
+    /**Can seed for reproducibility*/
+    private Random rand;
+    private boolean setSeed=false;
+    private int seed=0;
+
+    /** If trainAccuracy is required, a cross validation is done in buildClassifier
+     * or a OOB estimate is formed
+     If set, train results are overwritten with each call to buildClassifier
+     File opened on this path.*/
+    boolean trainAccuracyEst=false;
+    private String trainCVPath="";
+
+    /** voteEnsemble determines whether to aggregate classifications or
+     * probabilities when predicting */
+    private boolean voteEnsemble=true;
+
+    /** Flags and data required if Bagging **/
+    private boolean bagging=false; //Use if we want an OOB estimate
+    private ArrayList<boolean[]> inBag;
+    private int[] oobCounts;
+    private double[][] trainDistributions;
+
+    private boolean checkpoint = false;
+    private String checkpointPath;
+    private long checkpointTime = 0;
+    private long checkpointTimeElapsed= 0;
+
+    private boolean trainTimeContract = false;
+    private long contractTime = 0;
+
+    protected static final long serialVersionUID = 32554L;
+
+    public cTSF(){
+        rand=new Random();
+    }
+    public cTSF(int s){
+        rand=new Random();
+        seed=s;
+        rand.setSeed(seed);
+        setSeed=true;
+    }
+    /**
+     *
+     * @param c a base classifier constructed elsewhere and cloned into ensemble
+     */
+    public void setBaseClassifier(Classifier c){
+        base=c;
+    }
+    public void setBagging(boolean b){
+        bagging=b;
+    }
+
+    /**
+     * ok,  two methods are a bit pointless, experimenting with ensemble method
+     * @param b
+     */
+    public void setVoteEnsemble(boolean b){
+        voteEnsemble=b;
+    }
+    public void setProbabilityEnsemble(boolean b){
+        voteEnsemble=!b;
+    }
+
+    /**
+     * Seed experiments for reproducibility with the resample number
+     * @param s
+     */
+    @Override
+    public void setSeed(int s){
+        this.setSeed=true;
+        seed=s;
+        rand=new Random();
+        rand.setSeed(seed);
+    }
+    /**
+     * Stores the classifier train CV results and writes them to file.
+     * boolean trainCV is a little redundant, but nicer than checking path for null
+     * @param train
+     */
+    @Override
+    public void writeTrainEstimatesToFile(String train) {
+        trainCVPath=train;
+        trainAccuracyEst=true;
+    }
+    /**
+     * We can perform trainCV without writing the results to file. The could be used,
+     * for example, in an ensemble this TSF is a member of
+     * @param setCV
+     */
+    @Override
+    public void setFindTrainAccuracyEstimate(boolean setCV){
+        trainAccuracyEst=setCV;
+    }
+    /**
+     * Maybe this method needs renaming?
+     * @return boolean, whether trainCV happens or not
+     */
+    @Override
+    public boolean findsTrainAccuracyEstimate(){ return trainAccuracyEst;}
+
+    /**
+     *
+     * @return a ClassifierResults object, which will be null if tainCV is null
+     */
+    @Override
+    public ClassifierResults getTrainResults(){
+        return trainResults;
+    }
+    /**
+     * Perhaps make this coherent with setOptions(String[] ar)?
+     * @return String written to results files
+     */
+    @Override
+    public String getParameters() {
+        String temp=super.getParameters()+",numTrees,"+numClassifiers+",numIntervals,"+numIntervals+",voting,"+voteEnsemble+",BaseClassifier,"+base.getClass().getSimpleName()+",Bagging,"+bagging;
+        if(base instanceof RandomTree)
+            temp+=",AttsConsideredPerNode,"+((RandomTree)base).getKValue();
+        return temp;
+
+    }
+    public void setNumTrees(int t){
+        numClassifiers=t;
+    }
+
+
+    //<editor-fold defaultstate="collapsed" desc="results reported in Info Sciences paper">
+    static double[] reportedResults={
+            0.2659,
+            0.2302,
+            0.2333,
+            0.0256,
+            0.2537,
+            0.0391,
+            0.0357,
+            0.2897,
+            0.2,
+            0.2436,
+            0.049,
+            0.08,
+            0.0557,
+            0.2325,
+            0.0227,
+            0.101,
+            0.1543,
+            0.0467,
+            0.552,
+            0.6818,
+            0.0301,
+            0.1803,
+            0.2603,
+            0.0448,
+            0.2237,
+            0.119,
+            0.0987,
+            0.0865,
+            0.0667,
+            0.4339,
+            0.233,
+            0.1868,
+            0.0357,
+            0.1056,
+            0.1116,
+            0.0267,
+            0.02,
+            0.1177,
+            0.0543,
+            0.2102,
+            0.2876,
+            0.2624,
+            0.0054,
+            0.3793,
+            0.1513
+    };
+    //</editor-fold>
+
+    //<editor-fold defaultstate="collapsed" desc="problems used in Info Sciences paper">
+    static String[] problems={
+            "FiftyWords",
+            "Adiac",
+            "Beef",
+            "CBF",
+            "ChlorineConcentration",
+            "CinCECGtorso",
+            "Coffee",
+            "CricketX",
+            "CricketY",
+            "CricketZ",
+            "DiatomSizeReduction",
+            "ECG",
+            "ECGFiveDays",
+            "FaceAll",
+            "FaceFour",
+            "FacesUCR",
+            "Fish",
+            "GunPoint",
+            "Haptics",
+            "InlineSkate",
+            "ItalyPowerDemand",
+            "Lightning2",
+            "Lightning7",
+            "Mallat",
+            "MedicalImages",
+            "MoteStrain",
+            "NonInvasiveFetalECGThorax1",
+            "NonInvasiveFetalECGThorax2",
+            "OliveOil",
+            "OSULeaf",
+            "SonyAIBORobotSurface1",
+            "SonyAIBORobot Surface2",
+            "StarLightCurves",
+            "SwedishLeaf",
+            "Symbols",
+            "Synthetic Control",
+            "Trace",
+            "TwoLeadECG",
+            "TwoPatterns",
+            "UWaveGestureLibraryX",
+            "UWaveGestureLibraryY",
+            "UWaveGestureLibraryZ",
+            "Wafer",
+            "WordsSynonyms",
+            "Yoga"
+    };
+    //</editor-fold>
+
+    /**
+     * paper defining TSF
+     * @return TechnicalInformation
+     */
+    @Override
+    public TechnicalInformation getTechnicalInformation() {
+        TechnicalInformation 	result;
+        result = new TechnicalInformation(TechnicalInformation.Type.ARTICLE);
+        result.setValue(TechnicalInformation.Field.AUTHOR, "H. Deng, G. Runger, E. Tuv and M. Vladimir");
+        result.setValue(TechnicalInformation.Field.YEAR, "2013");
+        result.setValue(TechnicalInformation.Field.TITLE, "A time series forest for classification and feature extraction");
+        result.setValue(TechnicalInformation.Field.JOURNAL, "Information Sciences");
+        result.setValue(TechnicalInformation.Field.VOLUME, "239");
+        result.setValue(TechnicalInformation.Field.PAGES, "142-153");
+
+        return result;
+    }
+
+
+    /**
+     * main buildClassifier
+     * @param data
+     * @throws Exception
+     */
+    @Override
+    public void buildClassifier(Instances data) throws Exception {
+        // can classifier handle the data?
+        getCapabilities().testWithFail(data);
+        long t1=System.nanoTime();
+
+        //path checkpoint files will be saved to
+        File file = new File(checkpointPath + "TSF" + seed + ".ser");
+
+        //if checkpointing and serialised files exist load said files
+        if (checkpoint && file.exists()){
+            System.out.println("Loading from checkpoint file");
+            loadFromFile(checkpointPath + "TSF" + seed + ".ser");
+            checkpointTimeElapsed -= System.nanoTime()-t1;
+        }
+        //initialise variables
+        else {
+            numIntervals=numIntervalsFinder.apply(data.numAttributes()-1);
+            //Estimate train accuracy here if required and not using bagging
+//Set up instances size and format.
+            trees=new ArrayList(numClassifiers);
+
+            /** Set up for train rstimate **/
+            if(trainAccuracyEst) {
+                trainDistributions= new double[data.numInstances()][data.numClasses()];
+            }
+
+            /** Set up for Bagging **/
+            if(bagging){
+                inBag=new ArrayList();
+                oobCounts=new int[data.numInstances()];
+            }
+
+            //cancel loop using time instead of number built.
+            if (trainTimeContract){
+                numClassifiers = 0;
+            }
+
+            intervals = new ArrayList();
+        }
+
+        ArrayList<Attribute> atts=new ArrayList<>();
+        String name;
+        for(int j=0;j<numIntervals*3;j++){
+            name = "F"+j;
+            atts.add(new Attribute(name));
+        }
+        //Get the class values as an array list
+        Attribute target =data.attribute(data.classIndex());
+        ArrayList<String> vals=new ArrayList<>(target.numValues());
+        for(int j=0;j<target.numValues();j++)
+            vals.add(target.value(j));
+        atts.add(new Attribute(data.attribute(data.classIndex()).name(),vals));
+        //create blank instances with the correct class value
+        Instances result = new Instances("Tree",atts,data.numInstances());
+        result.setClassIndex(result.numAttributes()-1);
+        for(int i=0;i<data.numInstances();i++){
+            DenseInstance in=new DenseInstance(result.numAttributes());
+            in.setValue(result.numAttributes()-1,data.instance(i).classValue());
+            result.add(in);
+        }
+
+        testHolder =new Instances(result,0);
+        DenseInstance in=new DenseInstance(result.numAttributes());
+        testHolder.add(in);
+//Need to hard code this because log(m)+1 is sig worse than sqrt(m) is worse than using all!
+        if(base instanceof RandomTree){
+            ((RandomTree) base).setKValue(result.numAttributes()-1);
+//            ((RandomTree) base).setKValue((int)Math.sqrt(result.numAttributes()-1));
+        }
+
+        int classifiersBuilt = trees.size();
+
+        /** For each base classifier
+         *      generate random intervals
+         *      do the transfrorms
+         *      build the classifier
+         * */
+        while(((System.nanoTime()-t1)+checkpointTimeElapsed < contractTime || classifiersBuilt < numClassifiers)
+            && classifiersBuilt < maxClassifiers){
+            //1. Select random intervals for tree i
+            int[][] interval =new int[numIntervals][2];  //Start and end
+            if(data.numAttributes()-1<minIntervalLength)
+                minIntervalLength=data.numAttributes()-1;
+            for(int j=0;j<numIntervals;j++){
+                interval[j][0]=rand.nextInt(data.numAttributes()-1-minIntervalLength);       //Start point
+                int length=rand.nextInt(data.numAttributes()-1-interval[j][0]);//Min length 3
+                if(length<minIntervalLength)
+                    length=minIntervalLength;
+                interval[j][1]=interval[j][0]+length;
+            }
+            //2. Generate and store attributes
+            for(int j=0;j<numIntervals;j++){
+                //For each instance
+                for(int k=0;k<data.numInstances();k++){
+                    //extract the interval
+                    double[] series=data.instance(k).toDoubleArray();
+                    FeatureSet f= new FeatureSet();
+                    f.setFeatures(series, interval[j][0], interval[j][1]);
+                    result.instance(k).setValue(j*3, f.mean);
+                    result.instance(k).setValue(j*3+1, f.stDev);
+                    result.instance(k).setValue(j*3+2, f.slope);
+                }
+            }
+            //3. Create and build tree using all the features. Feature selection
+            Classifier tree = AbstractClassifier.makeCopy(base);
+            if(setSeed && tree instanceof Randomizable)
+                ((Randomizable)tree).setSeed(seed*(classifiersBuilt+1));
+            if(bagging){
+                boolean[] bag = new boolean[result.numInstances()];
+                Instances bagData = result.resampleWithWeights(rand, bag);
+                tree.buildClassifier(bagData);
+                if(trainAccuracyEst){
+                    for(int j=0;j<result.numInstances();j++){
+                        if(bag[j])
+                            continue;
+                        double[] newProbs = tree.distributionForInstance(result.instance(j));
+                        oobCounts[j]++;
+                        for(int k=0;k<newProbs.length;k++)
+                            trainDistributions[j][k]+=newProbs[k];
+
+                    }
+                }
+                inBag.add(bag);
+            }
+            else{
+                tree.buildClassifier(result);
+
+                if(trainAccuracyEst) {
+                    /** Defaults to 10 or numInstances, whichever is smaller.
+                     * Interface TrainAccuracyEstimate
+                     * Could this be handled better? */
+                    int numFolds = setNumberOfFolds(data);
+                    CrossValidationEvaluator cv = new CrossValidationEvaluator();
+                    if (setSeed)
+                        cv.setSeed(seed);
+                    cv.setNumFolds(numFolds);
+                    ClassifierResults results = cv.crossValidateWithStats(AbstractClassifier.makeCopy(base), result);
+
+                    for (int j = 0; j < result.numInstances(); j++) {
+                        double[] newProbs = results.getProbabilityDistribution(j);
+                        for (int k = 0; k < newProbs.length; k++)
+                            trainDistributions[j][k] += newProbs[k];
+                    }
+                }
+            }
+
+            intervals.add(interval);
+            trees.add(tree);
+            classifiersBuilt++;
+
+            if (checkpoint){
+                checkpoint(t1);
+            }
+        }
+
+        long t2=System.nanoTime();
+        //Store build time, this is always recorded
+        trainResults.setBuildTime((t2-t1)+checkpointTimeElapsed);
+        //If trainAccuracyEst ==true and we want to save results, write out object
+        if(trainAccuracyEst){
+            if(!bagging){//Do a CV
+                double[] preds=new double[data.numInstances()];
+                double[] actuals=new double[data.numInstances()];
+                for(int j=0;j<data.numInstances();j++){
+                    for(int k=0;k<trainDistributions[j].length;k++)
+                        trainDistributions[j][k]/=trees.size();
+                    preds[j]=utilities.GenericTools.indexOfMax(trainDistributions[j]);
+                    actuals[j]=data.instance(j).classValue();
+                }
+                long[] predTimes=new long[data.numInstances()];//Dummy variable, need something
+                trainResults.addAllPredictions(preds, trainDistributions, predTimes, null);
+                trainResults.setTimeUnit(TimeUnit.NANOSECONDS);
+                trainResults.setClassifierName("TSF");
+                trainResults.setDatasetName(data.relationName());
+                trainResults.setSplit("train");
+                trainResults.setFoldID(seed);
+                trainResults.setParas(getParameters());
+                trainResults.finaliseResults(actuals);
+
+//                /** Defaults to 10 or numInstances, whichever is smaller.
+//                 * Interface TrainAccuracyEstimate
+//                 * Could this be handled better? */
+//                int numFolds=setNumberOfFolds(data);
+//                CrossValidationEvaluator cv = new CrossValidationEvaluator();
+//                if (setSeed)
+//                    cv.setSeed(seed);
+//                cv.setNumFolds(numFolds);
+//                TSF tsf=new TSF();
+//                tsf.setFindTrainAccuracyEstimate(false);
+//                trainResults=cv.crossValidateWithStats(tsf,data);
+            }else{
+                // Use bag data. Normalise probs
+                double[] preds=new double[data.numInstances()];
+                double[] actuals=new double[data.numInstances()];
+                for(int j=0;j<data.numInstances();j++){
+                    for(int k=0;k<trainDistributions[j].length;k++)
+                        trainDistributions[j][k]/=oobCounts[j];
+                    preds[j]=utilities.GenericTools.indexOfMax(trainDistributions[j]);
+                    actuals[j]=data.instance(j).classValue();
+                }
+                long[] predTimes=new long[data.numInstances()];//Dummy variable, need something
+                trainResults.addAllPredictions(preds, trainDistributions, predTimes, null);
+                trainResults.setTimeUnit(TimeUnit.NANOSECONDS);
+                trainResults.setClassifierName("TSFBagging");
+                trainResults.setDatasetName(data.relationName());
+                trainResults.setSplit("train");
+                trainResults.setFoldID(seed);
+                trainResults.setParas(getParameters());
+                trainResults.finaliseResults(actuals);
+            }
+            if(trainCVPath!=""){
+                trainResults.writeFullResultsToFile(trainCVPath);
+/*                OutFile of=new OutFile(trainCVPath);
+                of.writeLine(data.relationName()+",TSF,train");
+                of.writeLine(getParameters());
+               of.writeLine(trainResults.getAcc()+"");
+               double[] trueClassVals,predClassVals;
+               trueClassVals=trainResults.getTrueClassValsAsArray();
+               predClassVals=trainResults.getPredClassValsAsArray();
+               for(int i=0;i<data.numInstances();i++){
+                   //Basic sanity check
+                   if(data.instance(i).classValue()!=trueClassVals[i]){
+                       throw new Exception("ERROR in TSF cross validation, class mismatch!");
+                   }
+                   of.writeString((int)trueClassVals[i]+","+(int)predClassVals[i]+",");
+                   for(double d:trainResults.getProbabilityDistribution(i))
+                       of.writeString(","+d);
+                   of.writeString("\n");
+               }
+*/
+            }
+        }
+
+    }
+    /**
+     * Sums either the
+     * @param ins to classifier
+     * @return array of doubles: probability of each class
+     * @throws Exception
+     */
+    @Override
+    public double[] distributionForInstance(Instance ins) throws Exception {
+        double[] d=new double[ins.numClasses()];
+        //Build transformed instance
+        double[] series=ins.toDoubleArray();
+        for(int i=0;i<trees.size();i++){
+            for(int j=0;j<numIntervals;j++){
+                //extract all intervals
+                FeatureSet f= new FeatureSet();
+                f.setFeatures(series, intervals.get(i)[j][0], intervals.get(i)[j][1]);
+                testHolder.instance(0).setValue(j*3, f.mean);
+                testHolder.instance(0).setValue(j*3+1, f.stDev);
+                testHolder.instance(0).setValue(j*3+2, f.slope);
+            }
+            if(voteEnsemble){
+                int c=(int)trees.get(i).classifyInstance(testHolder.instance(0));
+                d[c]++;
+            }else{
+                double[] temp=trees.get(i).distributionForInstance(testHolder.instance(0));
+                for(int j=0;j<temp.length;j++)
+                    d[j]+=temp[j];
+            }
+        }
+        double sum=0;
+        for(double x:d)
+            sum+=x;
+        for(int i=0;i<d.length;i++)
+            d[i]=d[i]/sum;
+        return d;
+    }
+    /**
+     * What about
+     * @param ins
+     * @return
+     * @throws Exception
+     */
+    @Override
+    public double classifyInstance(Instance ins) throws Exception {
+        double[] d=distributionForInstance(ins);
+        int max=0;
+        for(int i=1;i<d.length;i++)
+            if(d[i]>d[max])
+                max=i;
+        return (double)max;
+    }
+    /**
+     * Parses a given list of options to set the parameters of the classifier.
+     * We use this for the tuning mechanism, setting parameters through setOptions
+     <!-- options-start -->
+     * Valid options are: <p/>
+     * <pre> -T
+     * Number of trees.</pre>
+     *
+     * <pre> -I
+     * Number of intervals to fit.</pre>
+     *
+     <!-- options-end -->
+     *
+     * @param options the list of options as an array of strings
+     * @throws Exception if an option is not supported
+     */
+    @Override
+    public void setOptions(String[] options) throws Exception{
+        System.out.print("TSF para sets ");
+        for (String str:options)
+            System.out.print(","+str);
+        System.out.print("\n");
+        String numTreesString=Utils.getOption('T', options);
+        if (numTreesString.length() != 0)
+            numClassifiers = Integer.parseInt(numTreesString);
+        else
+            numClassifiers = DEFAULT_NUM_CLASSIFIERS;
+
+        String numFeaturesString=Utils.getOption('I', options);
+//Options here are a double between 0 and 1 (proportion of features), a text
+//string sqrt or log, or an integer number
+        if (numTreesString.length() != 0){
+            try{
+                if(numFeaturesString.equals("sqrt"))
+                    numIntervalsFinder = (numAtts) -> (int)(Math.sqrt(numAtts));
+                else if(numFeaturesString.equals("log"))
+                    numIntervalsFinder = (numAtts) -> (int) Utils.log2(numAtts) + 1;
+                else{
+                    double d=Double.parseDouble(numFeaturesString);
+                    if(d<=0)
+                        throw new Exception("proportion of features of of range 0 to 1");
+                    if(d<=1)
+                        numIntervalsFinder = (numAtts) -> (int)(d*numAtts);
+                    else
+                        numIntervalsFinder = (numAtts) -> (int)(d);
+
+//                        System.out.println("Proportion/number of intervals = "+d);
+                }
+            }catch(Exception e){
+                System.err.print(" Error: invalid parameter passed to TSF setOptions for number of parameters. Setting to default");
+                System.err.print("Value"+numIntervalsFinder+" Permissable values: sqrt, log, or a double range 0...1");
+                numIntervalsFinder = (numAtts) -> (int)(Math.sqrt(numAtts));
+            }
+        }
+        else
+            System.out.println("Unable to read number of intervals, not set");
+    }
+
+    @Override
+    public int getSeed() {
+        return seed;
+    }
+
+    @Override
+    public void setSavePath(String path) {
+        checkpointPath = path;
+        checkpoint = true;
+    }
+
+    @Override
+    public void copyFromSerObject(Object obj) throws Exception {
+        if(!(obj instanceof cTSF))
+            throw new Exception("The SER file is not an instance of TSF");
+        cTSF saved = ((cTSF)obj);
+        System.out.println("Loading TSF" + seed + ".ser");
+
+        try{
+            numClassifiers = saved.numClassifiers;
+            maxClassifiers = saved.maxClassifiers;
+            numIntervals = saved.numIntervals;
+            //numIntervalsFinder = saved.numIntervalsFinder;
+            minIntervalLength = saved.minIntervalLength;
+            trees = saved.trees;
+            base = saved.base;
+            intervals = saved.intervals;
+            //testHolder = saved.testHolder;
+            rand = saved.rand;
+            setSeed = saved.setSeed;
+            seed = saved.seed;
+            trainAccuracyEst = saved.trainAccuracyEst;
+            trainCVPath = saved.trainCVPath;
+            voteEnsemble = saved.voteEnsemble;
+            bagging = saved.bagging;
+            inBag = saved.inBag;
+            oobCounts = saved.oobCounts;
+            trainDistributions = saved.trainDistributions;
+            //checkpoint = saved.checkpoint;
+            //checkpointPath = saved.checkpointPath
+            checkpointTime = saved.checkpointTime;
+            checkpointTimeElapsed = saved.checkpointTime; //intentional, time spent building previously unchanged
+            trainTimeContract = saved.trainTimeContract;
+            contractTime = saved.contractTime;
+        }catch(Exception ex){
+            System.out.println("Unable to assign variables when loading serialised file");
+        }
+    }
+
+    @Override
+    public void setTrainTimeLimit(TimeUnit time, long amount) {
+        switch (time){
+            case DAYS:
+                contractTime = (long)(8.64e+13)*amount;
+                break;
+            case HOURS:
+                contractTime = (long)(3.6e+12)*amount;
+                break;
+            case MINUTES:
+                contractTime = (long)(6e+10)*amount;
+                break;
+            case SECONDS:
+                contractTime = (long)(1e+9)*amount;
+                break;
+            case NANOSECONDS:
+                contractTime = amount;
+                break;
+            default:
+                throw new InvalidParameterException("Invalid time unit");
+        }
+        trainTimeContract = true;
+    }
+
+    private void checkpoint(long startTime){
+        if(checkpointPath!=null){
+            try{
+                long t1 = System.nanoTime();
+                File f = new File(checkpointPath);
+                if(!f.isDirectory())
+                    f.mkdirs();
+
+                //time spent building so far.
+                checkpointTime = ((System.nanoTime() - startTime) + checkpointTimeElapsed);
+
+                //save this, classifiers and train data not included
+                saveToFile(checkpointPath + "TSF" + seed + "temp.ser");
+
+                File file = new File(checkpointPath + "TSF" + seed + "temp.ser");
+                File file2 = new File(checkpointPath + "TSF" + seed + ".ser");
+                file2.delete();
+                file.renameTo(file2);
+
+                checkpointTimeElapsed -= System.nanoTime()-t1;
+            }
+            catch(Exception e){
+                e.printStackTrace();
+                System.out.println("Serialisation to "+checkpointPath+"TSF" + seed + ".ser FAILED");
+            }
+        }
+    }
+
+    //Nested class to store three simple summary features used to construct train data
+    public static class FeatureSet{
+        public static boolean findSkew=false;
+        public static boolean findKurtosis=false;
+        double mean;
+        double stDev;
+        double slope;
+        double skew;
+        double kurtosis;
+        public void setFeatures(double[] data, int start, int end){
+            double sumX=0,sumYY=0;
+            double sumY3=0,sumY4=0;
+            double sumY=0,sumXY=0,sumXX=0;
+            int length=end-start+1;
+            for(int i=start;i<=end;i++){
+                sumY+=data[i];
+                sumYY+=data[i]*data[i];
+                sumX+=(i-start);
+                sumXX+=(i-start)*(i-start);
+                sumXY+=data[i]*(i-start);
+            }
+            mean=sumY/length;
+            stDev=sumYY-(sumY*sumY)/length;
+            slope=(sumXY-(sumX*sumY)/length);
+            double denom=sumXX-(sumX*sumX)/length;
+            if(denom!=0)
+                slope/=denom;
+            else
+                slope=0;
+            stDev/=length;
+            if(stDev==0)    //Flat line
+                slope=0;
+//            else //Why not doing this? Because not needed? 
+//                stDev=Math.sqrt(stDev);
+            if(slope==0)
+                stDev=0;
+            if(findSkew){
+                if(stDev==0)
+                    skew=1;
+                else{
+                    for(int i=start;i<=end;i++)
+                        sumY3+=data[i]*data[i]*data[i];
+                    skew=sumY3-3*sumY*sumYY+2*sumY*sumY;
+                    skew/=length*stDev*stDev*stDev;
+                }
+            }
+            if(findKurtosis){
+                if(stDev==0)
+                    kurtosis=1;
+                else{
+                    for(int i=start;i<=end;i++)
+                        sumY4+=data[i]*data[i]*data[i]*data[i];
+                    kurtosis=sumY4-4*sumY*sumY3+6*sumY*sumY*sumYY-3*sumY*sumY*sumY*sumY;
+                    skew/=length*stDev*stDev*stDev*stDev;
+                }
+            }
+
+        }
+        public void setFeatures(double[] data){
+            setFeatures(data,0,data.length-1);
+        }
+        @Override
+        public String toString(){
+            return "mean="+mean+" stdev = "+stDev+" slope ="+slope;
+        }
+    }
+
+    public static void main(String[] arg) throws Exception{
+// Basic correctness tests, including setting paras through 
+        String dataLocation="Z:\\Data\\TSCProblems2018\\";
+        String resultsLocation="C:\\temp\\";
+        String problem="ItalyPowerDemand";
+        File f= new File(resultsLocation+problem);
+        if(!f.isDirectory())
+            f.mkdirs();
+        Instances train=DatasetLoading.loadDataNullable(dataLocation+problem+"\\"+problem+"_TRAIN");
+        Instances test=DatasetLoading.loadDataNullable(dataLocation+problem+"\\"+problem+"_TEST");
+        cTSF tsf = new cTSF();
+        tsf.setSeed(0);
+        tsf.setTrainTimeLimit((long)1.5e+10);
+        tsf.setSavePath("C:\\temp\\");
+        tsf.writeTrainEstimatesToFile(resultsLocation+problem+"trainFold0.csv");
+        double a;
+        tsf.buildClassifier(train);
+        System.out.println("build ok: original atts="+(train.numAttributes()-1)+" new atts ="+tsf.testHolder.numAttributes()+" num trees = "+tsf.numClassifiers+" num intervals = "+tsf.numIntervals);
+        System.out.println(tsf.trainResults.getBuildTime());
+        a=ClassifierTools.accuracy(test, tsf);
+        System.out.println("Test Accuracy ="+a);
+        System.out.println();
+
+        tsf = new cTSF();
+        tsf.setSeed(1);
+        tsf.setTrainTimeLimit((long)1.5e+10);
+        tsf.setSavePath("C:\\temp\\");
+        String[] options=new String[4];
+        options[0]="-T";
+        options[1]="10";
+        options[2]="-I";
+        options[3]="1";
+        tsf.setOptions(options);
+        tsf.buildClassifier(train);
+        System.out.println("build ok: original atts="+(train.numAttributes()-1)+" new atts ="+tsf.testHolder.numAttributes()+" num trees = "+tsf.numClassifiers+" num intervals = "+tsf.numIntervals);
+        System.out.println(tsf.trainResults.getBuildTime());
+        a=ClassifierTools.accuracy(test, tsf);
+        System.out.println("Test Accuracy ="+a);
+
+
+    }
+}


### PR DESCRIPTION
Following the discussion on whether time spent acquiring a train accuracy estimate should be part of the contract and included in total build time, I have altered RBOSS to include the train estimate as part of its contract.

Alongside this (though it should be in a separate PR), a version of TSF with basic contracting and check-pointing has been added as a separate file. I decided to separate it to avoid conflicts with any local stuff Tony is doing, but it should ideally be merged into 1 in the future if it is kept.